### PR TITLE
Use SPDX IDs for communicating license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Automail primarily deals with:
 - Styling
 - Activity navigation
 
-# Available releases
+## Available releases
 
-As a userscript: https://greasyfork.org/en/scripts/370473-automail  
+As a userscript: https://greasyfork.org/en/scripts/370473-automail
 As a Firefox addon: https://addons.mozilla.org/en-US/firefox/addon/automail/
 
 Which one should you use? The userscript is rolling release, so you get new features immediately. There might be some bugs here and there, as they haven't been tested much. The firefox addon is updated every couple of months. It's intended to be more stable, and tries to meet the minimum security standards of mozilla. It is however often slightly outdated.
 
-# Build from source
+## Build from source
 
 "src/" contains a makefile, run "make" there.
 Requires make, m4 and basic shell utilities
@@ -26,4 +26,19 @@ Will build the userscript and the firefox addon in src/build/
 If you have an archived version of this repo, updated code can be found at
 https://github.com/hohMiyazawa/Automail
 
+## Copyright
 
+Copyright (C) 2019-2021 hoh and the Automail contributors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.

--- a/src/automail.m4
+++ b/src/automail.m4
@@ -10,8 +10,11 @@ m4_divert(0)m4_dnl
 // @author       hoh
 // @match        https://anilist.co/*
 // @grant        GM_xmlhttpRequest
-// @license      GPLv3
+// @license      GPL-3.0-or-later
 // ==/UserScript==
+// SPDX-FileCopyrightText: 2019-2021 hoh and the Automail contributors
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
 (function(){
 "use strict";
 const scriptInfo = {
@@ -23,7 +26,7 @@ const scriptInfo = {
 	"chrome" : "NO KNOWN BUILDS",
 	"author" : "hoh",
 	"authorLink" : "https://anilist.co/user/hoh/",
-	"license" : "GPLv3"
+	"license" : "GPL-3.0-or-later"
 };
 /*
 	A collection of enhancements for Anilist.co


### PR DESCRIPTION
Also add a copyright notice in both the README and final build.

The main benefit of using SPDX IDs is that `GPL-3.0-or-later` is much more clear than "GPLv3" and is also standardized.