### PR TITLE
Remove borders around images in notifications

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -189,9 +189,8 @@ m4_include(css/notifications.css)
 	height: 50px;
 	width: 50px;
 	display: inline-block;
-	background-position: 50%;
-	background-repeat: no-repeat;
-	background-size: cover;
+	object-position: center;
+	object-fit: cover;
 	margin-top: 11px;
 	margin-bottom: 1px;
 }

--- a/src/css/notifications.css
+++ b/src/css/notifications.css
@@ -76,7 +76,8 @@ span.hohMediaImageContainer{
 	width: 50px;
 	display: inline-block;
 	background-repeat: no-repeat;
-	background-size: cover;
+	object-fit: cover;
+	object-position: center;
 	line-height: 0;
 }
 .hohCommentsContainer{

--- a/src/modules/enhanceNotifications.js
+++ b/src/modules/enhanceNotifications.js
@@ -765,7 +765,7 @@ You can also turn off this notice there.`,setting)
 			if(type === "ANIME_LIST" || type === "MANGA_LIST"){
 				Array.from(document.getElementsByClassName(data.data.Activity.id)).forEach(stuff => {
 					stuff.style.backgroundColor = data.data.Activity.media.coverImage.color || "rgb(var(--color-foreground))";
-					stuff.style.backgroundImage = "url(" + data.data.Activity.media.coverImage.large + ")";
+					stuff.src = data.data.Activity.media.coverImage.large;
 					stuff.classList.add("hohBackgroundCover");
 					if(data.data.Activity.media.title){
 						stuff.parentNode.title = data.data.Activity.media.title.romaji
@@ -774,7 +774,7 @@ You can also turn off this notice there.`,setting)
 			}
 			else if(type === "TEXT"){
 				Array.from(document.getElementsByClassName(data.data.Activity.id)).forEach(stuff => {
-					stuff.style.backgroundImage = "url(" + data.data.Activity.user.avatar.large + ")";
+					stuff.src = data.data.Activity.user.avatar.large;
 					stuff.classList.add("hohBackgroundUserCover");
 					stuff.parentNode.style.background = "none"
 				})


### PR DESCRIPTION
Puts the image source link into the img element's src field and gave it the object-fit styling property to behave the same as background-size. This removes the border that appears when the browser thinks it isn't displaying an image in the img element. This is also better symantic html than just changing the element from img to div which would have the same effect.

![image](https://user-images.githubusercontent.com/16106839/115062581-ca63b500-9eea-11eb-9a8b-476f9c6dbf79.png)
