### PR TITLE
Fix additional stats not working as own user

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -151,9 +151,7 @@ query($name: String!){
 						}
 					}
 					else{
-						if(cache.lock.ANIME !== cache.lock.MANGA){
-							cache.forceUpdate()
-						}
+						cache.forceUpdate()
 					}
 				})
 			}


### PR DESCRIPTION
I think this fully fixes #49 as this has not been working for me for a while, even with persistent storage enabled.

Since the list cache is stored separately for each media type and from what I understand the lock is there to prevent other functions from trying to interact when it's in use, the extra lock comparison is not needed.

`addMoreStats` basically asks for both lists the moment the stats subpage is loaded so both cache locks will be set to true around the same time and the `forceUpdate` never happens.