### PR TITLE
Styling fixes

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1186,6 +1186,9 @@ m4_include(css/termsFeed.css)
 	position: relative;
 	min-height: 55px !important;
 }
+.hohSocialFeed .activity-replies{
+	margin: 20px;
+}
 .hohSocialFeed .reply-wrap time{
 	font-size: 1.1rem;
 }
@@ -1212,8 +1215,16 @@ m4_include(css/termsFeed.css)
 	padding: 10px 16px !important;
 }
 .hohSocialFeed .reply .avatar{
+	display: inline-block;
 	height: 25px;
 	width: 25px;
+	margin-top: 0;
+}
+.hohSocialFeed .reply .name{
+	display: inline-block;
+	line-height: 25px;
+	margin-left: 6px;
+	vertical-align: top;
 }
 .hohSocialFeed .activity-entry > .wrap > .actions{
 	bottom: 12px;

--- a/src/modules/replaceStaffRoles.js
+++ b/src/modules/replaceStaffRoles.js
@@ -343,13 +343,16 @@ let listRenderer = function(){
 	hohMediaRolesMangaHeader.style.display = "none";
 	hohCharacterRolesHeader.style.display = "none";
 	if(animeRolesList.length){
-		hohMediaRolesAnimeHeader.style.display = "inline"
+		hohMediaRolesAnimeHeader.style.display = "inline-block";
+		hohMediaRolesAnimeHeader.style.marginBottom = 0;
 	}
 	if(mangaRolesList.length){
-		hohMediaRolesMangaHeader.style.display = "inline"
+		hohMediaRolesMangaHeader.style.display = "inline-block";
+		hohMediaRolesMangaHeader.style.marginBottom = 0;
 	}
 	if(voiceRolesList.length){
-		hohCharacterRolesHeader.style.display = "inline"
+		hohCharacterRolesHeader.style.display = "inline-block";
+		hohCharacterRolesHeader.style.marginBottom = 0;
 	}
 	let createRoleCard = function(media,type){
 		let roleCard = create("div",["role-card","view-media"]);


### PR DESCRIPTION
First change fixes the margins on replies when using the social feed filters.

Before|After
--|--
![](https://discordjs.moe/ks16be6d1ml5.png)|![](https://discordjs.moe/gng7rz7p2kwj.png)

Second change reduces the spacing slightly between sections on staff pages.