### PR TITLE
Forum thread likes

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1978,6 +1978,10 @@ body.TMPreviewScore > .el-tooltip__popper{
 	width: max-content!important;
 	max-width: 800px;
 }
+.forum-thread .body .actions .like-wrap.hohHandledLike .users{
+	width: max-content!important;
+	max-width: 800px;
+}
 /*no !importants here, since Erwin is styling this on his own:*/
 .activity-feed .hohNoteSuffix:not(:empty),
 .activity-feed .hohRewatchSuffix:not(:empty),

--- a/src/modules/forumLikes.js
+++ b/src/modules/forumLikes.js
@@ -16,7 +16,7 @@ exportModule({
 			if((!data) || (!location.pathname.includes("forum/thread/" + URLstuff[1]))){
 				return
 			}
-			let button = document.querySelector(".footer .actions .button.like");
+			let button = document.querySelector(".footer .actions .like-wrap .button");
 			if(!button){
 				setTimeout(function(){adder(data)},200);
 				return;


### PR DESCRIPTION
Copied the code for displaying more likes on thread comments to make it work for the main thread post.

Main difference is I changed the API call to only get the first 20 users, so it doesn't try adding hundreds of more users to the `.users` list that won't be displayed anyways.

![](https://discordjs.moe/9ijdtddlxju0.png)

The other change prevents the list of users from appearing when hovering over the user avatars.