### PR TITLE
Anisongs improvements

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1985,7 +1985,7 @@ body.TMPreviewScore > .el-tooltip__popper{
 .anisongs .anisong-entry video {
 	cursor: auto;
 	margin-top: 10px;
-	width: 39em;
+	max-width: 100%;
 }
 .search .filter > .icon{
 	display: inline-block;

--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -12,7 +12,7 @@ exportModule({
 	categories: ["Media"],
 	visible: true,
 	urlMatch: function(url,oldUrl){
-		return ["anime","manga"].includes(window.location.pathname.split("/")[1])
+    return /^https:\/\/anilist\.co\/(anime|manga)\/[0-9]+\/.*/.test(url)
 	},
 	code: function(){
 const options = {
@@ -243,10 +243,10 @@ class Videos {
   }
 }
 
-let currentpath = window.location.pathname.split("/");
+let currentpath = location.pathname.match(/(anime|manga)\/([0-9]+)\/[^\/]*\/?(.*)/)
 if(currentpath[1] === "anime") {
 	let currentid = currentpath[2];
-	let location = currentpath.pop();
+	let location = currentpath[3];
 	if(location !== ""){
 		anisongs_temp.last = 0
 	}

--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -227,10 +227,17 @@ class Videos {
       }
       return url
     }
+    if(videos) {
+      return entries.map((e, i) => {
+        return {
+          title: cleanTitle(e),
+          url: findUrl(i)
+        }
+      })
+    }
     return entries.map((e, i) => {
       return {
-        title: cleanTitle(e),
-        url: findUrl(i)
+        title: cleanTitle(e)
       }
     })
   }

--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -53,10 +53,7 @@ const API = {
     }
   },
   async getSongs(mal_id) {
-    const splitSongs = list => list.flatMap(e => e.split(/\#\d{1,2}\s/)).filter(e => e!=="")
     let {opening_themes, ending_themes} = await request(`https://api.jikan.moe/v3/anime/${mal_id}/`)
-    opening_themes = splitSongs(opening_themes)
-    ending_themes = splitSongs(ending_themes)
     return {opening_themes, ending_themes}
   },
   async getVideos(anilist_id) {
@@ -219,8 +216,11 @@ class Videos {
   }
 
   static merge(entries, videos) {
+    const cleanTitle = song => {
+      return song.replace(/^#\d{1,2}:\s/, "")
+    }
     const findUrl = n => {
-      let url = null;
+      let url;
       if(videos[n]) {
         url = videos[n].animethemeentries[0]?.videos[0]?.link
         if(url) url = url.replace(/staging\./, "")
@@ -229,7 +229,7 @@ class Videos {
     }
     return entries.map((e, i) => {
       return {
-        title: e,
+        title: cleanTitle(e),
         url: findUrl(i)
       }
     })

--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -57,12 +57,7 @@ const API = {
     return {opening_themes, ending_themes}
   },
   async getVideos(anilist_id) {
-    const res = await request(`https://staging.animethemes.moe/api/anime?filter[has]=resources&filter[site]=AniList&filter[external_id]=${anilist_id}&include=animethemes.animethemeentries.videos`)
-    if(res.anime.length === 0){
-      return null
-    } else {
-      return res.anime[0];
-    }
+    return request(`https://staging.animethemes.moe/api/anime?filter[has]=resources&filter[site]=AniList&filter[external_id]=${anilist_id}&include=animethemes.animethemeentries.videos`)
   }
 }
 
@@ -201,8 +196,11 @@ class Videos {
   }
 
   async get() {
-    const {animethemes} = await API.getVideos(this.id);
-    return Videos.groupTypes(animethemes)
+    const {anime} = await API.getVideos(this.id);
+    if(anime.length === 0){
+      return {"OP":[], "ED":[]}
+    }
+    return Videos.groupTypes(anime[0].animethemes)
   }
 
   static groupTypes(songs) {


### PR DESCRIPTION
- Changed getting video links to the api provided by [Animethemes.moe](https://staging.animethemes.moe/api/docs/) instead of html parsing of reddit
  - This directly gets OP/ED links for the anime (using anilist id) instead of every anime in its release year
- Fixed parsing of song title data from jikan (e.g. [Evangelion EDs](https://anilist.co/anime/30/Shin-Seiki-Evangelion/))
- Limited the width of videos to fit within the column (allows an OP and ED to be open side-by-side)

Somewhat related, there's a bug introduced with dce1d2e37381e4db6fc9c6f16a1d8af69fbd8b2e where anisongs data can be written to the `automail` indexeddb instead of `Anisongs` and vice-versa depending on how the site is navigated. I didn't fix it for this PR as I'm unsure if it's intended to have separate databases instead of just sharing a single one.