### PR TITLE
Fix indexeddb conflict

### DIFF
--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -16,14 +16,9 @@ exportModule({
 	},
 	code: function(){
 const options = {
-  cacheName: 'anison', // name in localstorage
   cacheTTL: 604800000, // 1 week in ms
   class: 'anisongs', // container class
 }
-
-localforage.config({
-    name: 'Anisongs'
-})
 
 const Cache = {
   async add(key, value) {


### PR DESCRIPTION
Continued from #100

>As the API usage is now different, I think it makes sense to use the automail storage instead of the anisongs one.

The script should now use the config that runs from https://github.com/hohMiyazawa/Automail/blob/master/src/cache.js before the modules.