### PR TITLE
Fixing the Media Title Replacement thing

### DIFF
--- a/src/modules/addForumMediaTitle.js
+++ b/src/modules/addForumMediaTitle.js
@@ -2,7 +2,8 @@ function addForumMediaTitle(){
 	if(location.pathname !== "/home"){
 		return
 	}
-	let forumThreads = Array.from(document.querySelectorAll(".home .forum-wrap .thread-card .category"));
+	// Forum previews may contain multiple categories but only show the first one
+	let forumThreads = Array.from(document.querySelectorAll(".home .forum-wrap .thread-card .categories span:first-child .category"));
 	if(!forumThreads.length){
 		setTimeout(addForumMediaTitle,200);
 		return;


### PR DESCRIPTION
So i randomly stumbled upon an issue where the `anime/manga` was present but didn't get replaced by the `addForumMediaTitle` module.
After a bit of research i found out that the forum previews actually could contain multiple `.category` links but only the first one would be shown.
This would cause `forumThreads` to have a length of >3 and making the index from the loop through the API results target the wrong elements.
I changed the selector to only retrieve the first categories which are shown which should fix this issue.
![:blobcatgooglyeyesalute:](https://cdn.discordapp.com/emojis/838683158416850984.png?size=48)
