### PR TITLE
Migrate tag descriptions to module

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -234,9 +234,6 @@ function handleScripts(url,oldUrl){
 				setTimeout(adder,500)
 			}
 		};adder();
-		if(useScripts.tagDescriptions){
-			enhanceTags()
-		};
 		if(useScripts.subTitleInfo){
 			addSubTitleInfo()
 		}

--- a/src/data/legacyModuleDescriptions.json
+++ b/src/data/legacyModuleDescriptions.json
@@ -29,9 +29,6 @@
 },{"id": "automailAPI",
 	"description": "Enable an API for other scripts to control automail [Don't enable this unless you know what you are doing]",
 	"categories": ["Script","Login"]
-},{"id": "tagDescriptions",
-	"description": "$tagDescriptions_description",
-	"categories": ["Media"]
 },{"id": "MALscore",
 	"description": "$setting_MALscore",
 	"categories": ["Media"]

--- a/src/modules/enhanceTags.js
+++ b/src/modules/enhanceTags.js
@@ -1,35 +1,59 @@
-function enhanceTags(){//show tag definition in drop down menu when adding tags
-	if(!location.pathname.match(/^\/(anime|manga)\/.*/)){
-		return
-	};
-	setTimeout(enhanceTags,400);
-	let possibleTagContainers = Array.from(document.querySelectorAll(".el-select-dropdown__list"));
-	let bestGuess = possibleTagContainers.find(
-		elem => elem.children.length > 205//horrible test, but we have no markup to go from. Assumes the tag dropdown is the only one with more than that number of children
-	)
-	if(!bestGuess){
-		return
-	};
-	if(bestGuess.hasOwnProperty("hohMarked")){
-		return
-	}
-	else{
-		bestGuess.hohMarked = true
-	};
-	let superBody = document.getElementsByClassName("el-dialog__body")[0];
-	let descriptionTarget = create("span","#hohDescription");
-	superBody.insertBefore(descriptionTarget,superBody.children[2]);
-	Array.from(bestGuess.children).forEach(child => {
-		child.onmouseover = function(){
-			if(tagDescriptions[child.children[0].innerText]){
-				document.getElementById("hohDescription").innerText = tagDescriptions[child.children[0].innerText];
+exportModule({
+	id: "tagDescriptions",
+	description: "$tagDescriptions_description",
+	isDefault: true,
+	categories: ["Media"],
+	visible: true,
+	urlMatch: function(url,oldUrl){
+		return /^https:\/\/anilist\.co\/(anime|manga)\/\d+\/[^/]+\/?(.*)?/.test(url)
+	},
+	code: function(){
+		function enhanceTags(){
+			let possibleTagContainers = Array.from(document.querySelectorAll(".el-select-dropdown__list"));
+			let bestGuess = possibleTagContainers.find(
+				elem => elem.children.length > 205//horrible test, but we have no markup to go from. Assumes the tag dropdown is the only one with more than that number of children
+			)
+			if(!bestGuess){
+				setTimeout(enhanceTags,400);
+				return
+			};
+			if(bestGuess.hasOwnProperty("hohMarked")){
+				return
 			}
-			else if(child.children[0].innerText !== ""){
-				document.getElementById("hohDescription").innerText = "Message hoh to get this description added";//should never happen anymore
+			else{
+				bestGuess.hohMarked = true
+			};
+			let superBody = document.getElementsByClassName("el-dialog__body")[0];
+			let descriptionTarget = create("span","#hohDescription");
+			superBody.insertBefore(descriptionTarget,superBody.children[2]);
+
+			function addHandler(child){
+				child.onmouseover = function(){
+					if(tagDescriptions[child.children[0].innerText]){
+						document.getElementById("hohDescription").innerText = tagDescriptions[child.children[0].innerText];
+					}
+				};
+				child.onmouseout = function(){
+					document.getElementById("hohDescription").innerText = ""
+				}
 			}
-		};
-		child.onmouseout = function(){
-			document.getElementById("hohDescription").innerText = ""
+			function checkCustomTag(){
+				if(!bestGuess.children[0].onmouseover || !bestGuess.children[0].onmouseout){
+					addHandler(bestGuess.children[0])
+				}
+			}
+			Array.from(bestGuess.children).forEach(child => addHandler(child))
+			setInterval(checkCustomTag, 400);
 		}
-	})
-};
+		function checkAddTag(){
+			const addTag = document.querySelector(".tags .add-icon")
+			if(addTag){
+				addTag.addEventListener("click", enhanceTags)
+			}
+			else{
+				setTimeout(checkAddTag, 400)
+			}
+		}
+		checkAddTag()
+	}
+})

--- a/src/settings.js
+++ b/src/settings.js
@@ -35,7 +35,6 @@ let useScripts = {
 	forumComments: true,
 	forumMedia: true,
 	staffPages: true,
-	tagDescriptions: true,
 	completedScore: true,
 	droppedScore: false,
 	studioFavouriteCount: true,


### PR DESCRIPTION
- migrated to module format
- fixed a bug where custom tags (i.e. nsfw tags) would eventually fail to show its description
  - what would happen is the description would fill normally until the tag input box was cleared, then the site would delete the blank node. so when input was entered again a new node was created without the `onmouseover` and `onmouseout` handlers.
- changed the main script to only run once the "add tag" icon has been clicked
- removed message about adding missing tag descriptions