### PR TITLE
Extra favs enhancements

### DIFF
--- a/src/modules/extraFavs.js
+++ b/src/modules/extraFavs.js
@@ -85,6 +85,8 @@ query($user: String!){
 					if(!data){
 						return//could be a private profile
 					}
+					const firstFav = favSection.children[0].getAttributeNames();
+					const dataAttrs = firstFav.filter((attr) => attr.includes("data"));
 					let findTooltip = function(){
 						let possibleTooltip = document.querySelector(".tooltip.visible.animate-position");
 						if(
@@ -117,6 +119,7 @@ query($user: String!){
 						data.data.User.favourites.anime3.nodes
 					).forEach(fav => {
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
+						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/anime/" + fav.id + "/" + safeURL(titlePicker(fav));
 						element.onmouseover = function(){
 							let possibleTooltip = findTooltip();
@@ -217,6 +220,8 @@ query($user: String!){
 					if(!data){
 						return//could be a private profile
 					}
+					const firstFav = favSection.children[0].getAttributeNames();
+					const dataAttrs = firstFav.filter((attr) => attr.includes("data"));
 					let findTooltip = function(){
 						let possibleTooltip = document.querySelector(".tooltip.visible.animate-position");
 						if(possibleTooltip.innerText.match(/(TV|Movie)$/)){
@@ -252,6 +257,7 @@ query($user: String!){
 						data.data.User.favourites.manga3.nodes
 					).forEach(fav => {
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
+						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/manga/" + fav.id + "/" + safeURL(titlePicker(fav));
 						element.onmouseover = function(){
 							let possibleTooltip = findTooltip();
@@ -286,19 +292,6 @@ query($user: String!){
 		};finder2()
 	},
 	css: `
-.hohExtraFav{
-	background-position: 50%;
-	background-repeat: no-repeat;
-	background-size: cover;
-	border-radius: 4px;
-	cursor: pointer;
-	display: inline-block;
-	height: 115px;
-	position: relative;
-	width: 85px;
-	margin-bottom: 20px;
-	margin-right: 21px;
-}
 .hohExtraFavs:hover{
 	overflow-y: auto;
 	scrollbar-width: none;

--- a/src/modules/extraFavs.js
+++ b/src/modules/extraFavs.js
@@ -146,6 +146,12 @@ query($user: String!){
 								element.title = titlePicker(fav)
 							}
 						}
+						element.onmouseout = function(){
+							let possibleTooltip = findTooltip();
+							if(possibleTooltip){
+								possibleTooltip.classList.remove("visible");
+							}
+						}
 					})
 				},
 				"hohExtraFavs" + URLstuff[1],
@@ -282,6 +288,12 @@ query($user: String!){
 							}
 							else{
 								element.title = titlePicker(fav)
+							}
+						}
+						element.onmouseout = function(){
+							let possibleTooltip = findTooltip();
+							if(possibleTooltip){
+								possibleTooltip.classList.remove("visible");
 							}
 						}
 					})

--- a/src/modules/extraFavs.js
+++ b/src/modules/extraFavs.js
@@ -81,7 +81,7 @@ query($user: String!){
 					user: decodeURIComponent(URLstuff[1]),
 				},
 				function(data){
-					favSection.style.height = (favSection.clientHeight || 615) + "px";
+					favSection.style.maxHeight = (favSection.clientHeight || 615) + "px";
 					if(!data){
 						return//could be a private profile
 					}
@@ -213,7 +213,7 @@ query($user: String!){
 					user: decodeURIComponent(URLstuff[1]),
 				},
 				function(data){
-					favSection.style.height = (favSection.clientHeight || 615) + "px";
+					favSection.style.maxHeight = (favSection.clientHeight || 615) + "px";
 					if(!data){
 						return//could be a private profile
 					}

--- a/src/modules/extraFavs.js
+++ b/src/modules/extraFavs.js
@@ -85,8 +85,6 @@ query($user: String!){
 					if(!data){
 						return//could be a private profile
 					}
-					const firstFav = favSection.children[0].getAttributeNames();
-					const dataAttrs = firstFav.filter((attr) => attr.includes("data"));
 					let findTooltip = function(){
 						let possibleTooltip = document.querySelector(".tooltip.visible.animate-position");
 						if(
@@ -119,7 +117,6 @@ query($user: String!){
 						data.data.User.favourites.anime3.nodes
 					).forEach(fav => {
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
-						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/anime/" + fav.id + "/" + safeURL(titlePicker(fav));
 						cheapReload(element,{path: element.pathname})
 						element.onmouseover = function(){
@@ -227,8 +224,6 @@ query($user: String!){
 					if(!data){
 						return//could be a private profile
 					}
-					const firstFav = favSection.children[0].getAttributeNames();
-					const dataAttrs = firstFav.filter((attr) => attr.includes("data"));
 					let findTooltip = function(){
 						let possibleTooltip = document.querySelector(".tooltip.visible.animate-position");
 						if(possibleTooltip.innerText.match(/(TV|Movie)$/)){
@@ -264,7 +259,6 @@ query($user: String!){
 						data.data.User.favourites.manga3.nodes
 					).forEach(fav => {
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
-						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/manga/" + fav.id + "/" + safeURL(titlePicker(fav));
 						cheapReload(element,{path: element.pathname})
 						element.onmouseover = function(){
@@ -306,6 +300,19 @@ query($user: String!){
 		};finder2()
 	},
 	css: `
+.hohExtraFav{
+	background-position: 50%;
+	background-repeat: no-repeat;
+	background-size: cover;
+	border-radius: 4px;
+	cursor: pointer;
+	display: inline-block;
+	height: 115px;
+	position: relative;
+	width: 85px;
+	margin-bottom: 20px;
+	margin-right: 21px;
+}
 .hohExtraFavs:hover{
 	overflow-y: auto;
 	scrollbar-width: none;

--- a/src/modules/extraFavs.js
+++ b/src/modules/extraFavs.js
@@ -121,6 +121,7 @@ query($user: String!){
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
 						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/anime/" + fav.id + "/" + safeURL(titlePicker(fav));
+						cheapReload(element,{path: element.pathname})
 						element.onmouseover = function(){
 							let possibleTooltip = findTooltip();
 							if(possibleTooltip){
@@ -265,6 +266,7 @@ query($user: String!){
 						let element = create("a",["favourite","media","hohExtraFav"],false,favSection,'background-image: url("' + fav.coverImage.large + '")');
 						dataAttrs.forEach(attr => element.setAttribute(attr, ""))
 						element.href = "/manga/" + fav.id + "/" + safeURL(titlePicker(fav));
+						cheapReload(element,{path: element.pathname})
 						element.onmouseover = function(){
 							let possibleTooltip = findTooltip();
 							if(possibleTooltip){


### PR DESCRIPTION
- changed the fav container to set `max-height` instead of `height`
  - fixes an issue where the container would remain the same height when navigating from a profile with extra favs to one without
- ~copied the vue ids from the first fav found to extra favs so the native styling is used~
- added `onmouseout` event to extra favs so the tooltip disappears properly
- added native routing to extra favs

Sidenote: I noticed https://github.com/hohMiyazawa/Automail/commit/b4ba4884553aa3635b97cdce8571a5173ebf458e was applied for anime favs but not for manga. I don't have a profile to test for (extra) manga favs so I don't know if the same fix is needed or not.