### PR TITLE
Api rewrite

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -1,5 +1,4 @@
 //begin "cache.js"
-localforage.config({name: 'automail'});//can't be named just 'localforage', as Anilist uses it too
 
 let reliablePersistentStorage = true;
 if (navigator.storage && navigator.storage.persist){

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -748,7 +748,12 @@ async function saveCache(key, data, duration){
 				return flushCache();
 			}
 			catch(e){
-				throw new Error(e)
+				try{
+					return apiCache.clear();//clear all items in the store if flushing fails
+				}
+				catch(e){
+					throw new Error(e)
+				}
 			}
 		}
 		else{
@@ -780,7 +785,12 @@ async function updateCache(key, newData){
 					return flushCache();
 				}
 				catch(e){
-					throw new Error(e)
+					try{
+						return apiCache.clear();//clear all items in the store if flushing fails
+					}
+					catch(e){
+						throw new Error(e)
+					}
 				}
 			}
 			else{

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -686,7 +686,7 @@ async function checkCache(key, persist){
 	const item = persist === true ? await apiPersistCache.getItem(key) : apiCache[key];
 	if(item){
 		if(!item.duration || (NOW() < item.time + item.duration)){
-			return item;
+			return item.data;
 		}
 		else{
 			if(persist === true){

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -628,4 +628,48 @@ function authAPIcall(query,variables,callback,cacheKey,timeFresh,useLocalStorage
 	APIcallsUsed++
 }
 const ANILIST_QUERY_LIMIT = 90;
+
+
+class QueryArgs{
+	constructor(args){
+		this.variables = args[variables] || {}
+		this.cacheKey = args[cacheKey] || null
+		this.timeFresh = args[timeFresh] || null
+		this.useLocalStorage = args[useLocalStorage] || false
+		this.overWrite = args[overWrite] || false
+		this.auth = args[auth] || false
+		/*const validArgs = ["variables", "cacheKey", "timeFresh", "useLocalStorage", "overWrite", "auth"];
+		Object.entries(args).forEach(([k, v]) => {
+			if(validArgs.includes(k)) this[k] = v
+		})*/
+	}
+}
+
+class QueryOptions{
+	constructor(query, variables, auth){
+		function isAuth(){
+			if(auth === true && useScripts.accessToken) return "Bearer " + useScripts.accessToken
+			return null
+		}
+		this.method = "POST",
+		this.headers = {
+			"Authorization": isAuth(),
+			"Content-Type": "application/json",
+			"Accept": "application/json"
+		},
+		this.body = JSON.stringify({
+			"query": query,
+			"variables": variables
+		})
+	}
+}
+
+async function anilistAPI(query, args){
+	if(!query) return "No query provided"
+	const queryArgs = new QueryArgs(args);
+	const options = new QueryOptions(query, queryArgs.variables, queryArgs.auth);
+	const res = await fetch(url, options);
+	APIcallsUsed++;
+	return res.json();
+}
 //end "graphql.js"

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -687,8 +687,12 @@ class RequestOptions{
  * @param {Response} res - The Response object from a network request.
  */
 function updateLimit(res){
-	APIlimit = res.headers.get("x-ratelimit-limit");
-	APIcallsUsed = APIlimit - res.headers.get("x-ratelimit-remaining");
+	if(res.headers.has("x-ratelimit-limit")){
+		APIlimit = res.headers.get("x-ratelimit-limit");
+	}
+	if(res.headers.has("x-ratelimit-remaining")){
+		APIcallsUsed = APIlimit - res.headers.get("x-ratelimit-remaining");
+	}
 }
 
 /**
@@ -845,8 +849,16 @@ async function anilistAPI(query, queryArgs){
 			}
 		}
 		if(res.status === 429){
-			console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
-			apiResetLimit = res.headers.get("x-ratelimit-reset");
+			if(res.headers.has("retry-after")){
+				console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
+			}
+			if(res.headers.has("x-ratelimit-reset")){
+				apiResetLimit = res.headers.get("x-ratelimit-reset");
+			}
+			else{
+				apiResetLimit = (NOW()+60*1000)/1000;
+				throw new Error("Exceeded AniList API request limit. Please report the issue at https://github.com/hohMiyazawa/Automail/issues")
+			}
 		}
 		else if(res.status !== 404){
 			console.error(`AniList API returned ${res.status} ${res.statusText}`)

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -664,12 +664,17 @@ class QueryOptions{
 	}
 }
 
+function updateLimit(res){
+	APIlimit = res.headers.get("x-ratelimit-limit");
+	APIcallsUsed = APIlimit - res.headers.get("x-ratelimit-remaining");
+}
+
 async function anilistAPI(query, args){
 	if(!query) return "No query provided"
 	const queryArgs = new QueryArgs(args);
 	const options = new QueryOptions(query, queryArgs.variables, queryArgs.auth);
 	const res = await fetch(url, options);
-	APIcallsUsed++;
-	return res.json();
+	updateLimit(res);
+	return (res.ok ? res.json() : Promise.reject(res.json()));
 }
 //end "graphql.js"

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -837,6 +837,13 @@ async function anilistAPI(query, queryArgs){
 		}
 	}
 	else{
+		if(data.errors){
+			if(data.errors.some(thing => thing.message === "Invalid token")){//status 400
+				useScripts.accessToken = "";
+				useScripts.save();
+				console.warn("Access token retracted.");
+			}
+		}
 		if(res.status === 429){
 			console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
 			apiResetLimit = res.headers.get("x-ratelimit-reset");

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -681,6 +681,15 @@ async function checkCache(key){
 	return null;
 }
 
+function saveCache(data, key, duration){
+	const saltedHam = {
+		data: data,
+		time: NOW(),
+		duration: duration
+	}
+	apiCache.setItem(key, saltedHam);
+}
+
 async function anilistAPI(query, args){
 	if(!query) return "No query provided"
 	const queryArgs = new QueryArgs(args);
@@ -691,6 +700,11 @@ async function anilistAPI(query, args){
 	}
 	const res = await fetch(url, options);
 	updateLimit(res);
-	return (res.ok ? res.json() : Promise.reject(res.json()));
+	const data = await res.json();
+	if(res.ok){
+		if(queryArgs.cacheKey) saveCache(data, queryArgs.cacheKey, queryArgs.timeFresh);
+		return data;
+	}
+	return Promise.reject(data);
 }
 //end "graphql.js"

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -668,7 +668,9 @@ class RequestOptions{
 	}
 	#isInternal(internal){
 		if(internal === true){
-			if(al_token) this.headers.set("x-csrf-token", al_token)
+			if(al_token){
+				this.headers.set("x-csrf-token", al_token)
+			}
 			this.headers.set("schema", "internal")
 		}
 	}
@@ -697,7 +699,7 @@ function saveCache(data, key, duration){
 		data: data,
 		createdAt: NOW(),
 		expiresAt: duration ? NOW() + duration*1000 : undefined
-	}
+	};
 	try{
 		apiCache.setItem(key, saltedHam);
 	}
@@ -715,38 +717,47 @@ function saveCache(data, key, duration){
 }
 
 async function anilistAPI(query, queryArgs){
-	if(!query) throw new Error("No query provided")
+	if(!query){
+		throw new Error("No query provided")
+	}
 	let apiUrl = url;
 	const args = new QueryOptions(queryArgs);
 	const options = new RequestOptions(query, args.variables, args.auth, args.internal);
 	if(args.cacheKey && !args.overwrite){
 		const cache = await checkCache(args.cacheKey);
-		if(cache) return cache;
+		if(cache){
+			return cache;
+		}
 	}
 	if(apiResetLimit){
 		if(NOW() < apiResetLimit*1000){
-			console.warn(`API limit resets at ${new Date(apiResetLimit*1000).toLocaleString()}`);
 			return null;
 		}
 		apiResetLimit = null;
 	}
-	if(args.internal === true) apiUrl = "https://anilist.co/graphql";
+	if(args.internal === true){
+		apiUrl = "https://anilist.co/graphql";
+	}
 	const res = await fetch(apiUrl, options);
-	if(args.internal !== true) updateLimit(res);
+	if(args.internal !== true){
+		updateLimit(res);
+	}
 	const data = await res.json();
 	if(res.ok){
-		if(args.cacheKey) saveCache(data, args.cacheKey, args.duration);
+		if(args.cacheKey){
+			saveCache(data, args.cacheKey, args.duration);
+		}
 		return data;
 	}
 	else if(res.status === 404){
 		return null;
 	}
 	else if(res.status === 429){
-		console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`);
+		console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
 		apiResetLimit = res.headers.get("x-ratelimit-reset");
 		return null;
 	}
-	console.error(`AniList API returned ${res.status} ${res.statusText}`);
+	console.error(`AniList API returned ${res.status} ${res.statusText}`)
 	return null;
 }
 //end api v2

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -694,7 +694,7 @@ function updateLimit(res){
 /**
  * Checks the API cache for an existing item and returns it if it has not expired
  * @param {string} key - The key to check for in the datastore.
- * @returns {Promise<object|null>} The cached data or nothing.
+ * @returns {Promise<object>} The cached data if found.
  */
 async function checkCache(key){
 	const item = await apiCache.getItem(key);
@@ -706,7 +706,7 @@ async function checkCache(key){
 			return apiCache.removeItem(key);
 		}
 	}
-	return null;
+	return;
 }
 
 /**
@@ -833,17 +833,17 @@ async function anilistAPI(query, queryArgs){
 	const data = await res.json();
 	if(res.ok){
 		if(args.cacheKey){
-			await saveCache(args.cacheKey, data, args.duration);
+			saveCache(args.cacheKey, data, args.duration);
 		}
 	}
-	else if(res.status === 404){
-	}
-	else if(res.status === 429){
-		console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
-		apiResetLimit = res.headers.get("x-ratelimit-reset");
-	}
 	else{
-		console.error(`AniList API returned ${res.status} ${res.statusText}`)
+		if(res.status === 429){
+			console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
+			apiResetLimit = res.headers.get("x-ratelimit-reset");
+		}
+		else if(res.status !== 404){
+			console.error(`AniList API returned ${res.status} ${res.statusText}`)
+		}
 	}
 	return data;
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -832,18 +832,17 @@ async function anilistAPI(query, queryArgs){
 		if(args.cacheKey){
 			await saveCache(args.cacheKey, data, args.duration);
 		}
-		return data;
 	}
 	else if(res.status === 404){
-		return null;
 	}
 	else if(res.status === 429){
 		console.warn(`Exceeded AniList API request limit. Limit resets in ${res.headers.get("retry-after")} seconds.`)
 		apiResetLimit = res.headers.get("x-ratelimit-reset");
-		return null;
 	}
-	console.error(`AniList API returned ${res.status} ${res.statusText}`)
-	return null;
+	else{
+		console.error(`AniList API returned ${res.status} ${res.statusText}`)
+	}
+	return data;
 }
 
 /**

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -845,5 +845,23 @@ async function anilistAPI(query, queryArgs){
 	console.error(`AniList API returned ${res.status} ${res.statusText}`)
 	return null;
 }
+
+/**
+ * Runs an API cache checkup weekly
+ * @returns {Promise|null}
+ */
+const cacheCheckup = async () => {
+	const check = localStorage.getItem("automail-db-check")
+	if(check){
+		if(NOW() > check){
+			localStorage.setItem("automail-db-check", NOW()+7*24*60*60*1000)
+			return await flushCache();
+		}
+		return null;
+	}
+	localStorage.setItem("automail-db-check", NOW()+7*24*60*60*1000)
+	return null;
+};
+cacheCheckup()
 //end api v2
 //end "graphql.js"

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -289,7 +289,7 @@ if(window.BroadcastChannel){
 				cache.updateIfDifferent(message.data.mediaData,true)
 			}
 			else if(message.data.type === "cachev3"){
-				apiCache[message.data.key] = message.data.value
+				apiCache.set(message.data.key, message.data.value)
 			}
 			else if(message.data.type === "sessionToken"){
 				window.al_token = message.data.value
@@ -636,7 +636,7 @@ localforage.config({name: "automail"});
 
 //begin api v2
 const apiPersistCache = localforage.createInstance({name: "automail", storeName: "api"});
-const apiCache = {};
+const apiCache = new Map();
 let apiResetLimit;
 
 class QueryOptions{
@@ -685,7 +685,7 @@ function updateLimit(res){
 }
 
 async function checkCache(key, persist){
-	const item = persist === true ? await apiPersistCache.getItem(key) : apiCache[key];
+	const item = persist === true ? await apiPersistCache.getItem(key) : apiCache.get(key);
 	if(item){
 		if(!item.expiresAt || (NOW() < item.expiresAt)){
 			return item.data;
@@ -694,7 +694,7 @@ async function checkCache(key, persist){
 			if(persist === true){
 				return apiPersistCache.removeItem(key);
 			}
-			delete apiCache[key];
+			apiCache.delete(key);
 			return null;
 		}
 	}
@@ -724,7 +724,7 @@ function saveCache(data, key, duration, persist){
 		}
 	}
 	else{
-		apiCache[key] = saltedHam;
+		apiCache.set(key, saltedHam);
 		aniCast.postMessage({type:"cachev3",key:key,value:saltedHam})
 	}
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -633,16 +633,13 @@ localforage.config({name: "automail"});
 const apiCache = localforage.createInstance({storeName: "api"});
 
 class QueryArgs{
-	constructor(args){
-		this.variables = args[variables] || {}
-		this.cacheKey = args[cacheKey] || null
-		this.timeFresh = args[timeFresh] || null
-		this.overWrite = args[overWrite] || false
-		this.auth = args[auth] || false
-		/*const validArgs = ["variables", "cacheKey", "timeFresh", "useLocalStorage", "overWrite", "auth"];
-		Object.entries(args).forEach(([k, v]) => {
-			if(validArgs.includes(k)) this[k] = v
-		})*/
+	constructor(args={}){
+		this.variables = {};
+		this.cacheKey = null;
+		this.timeFresh = null;
+		this.overWrite = false;
+		this.auth = false;
+		Object.assign(this, args);
 	}
 }
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -630,7 +630,7 @@ function authAPIcall(query,variables,callback,cacheKey,timeFresh,useLocalStorage
 const ANILIST_QUERY_LIMIT = 90;
 
 localforage.config({name: "automail"});
-const apiCache = localforage.createInstance({storeName: "api"});
+const apiCache = localforage.createInstance({name: "automail", storeName: "api"});
 
 class QueryArgs{
 	constructor(args={}){

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -706,7 +706,20 @@ function saveCache(data, key, duration, persist){
 		duration: duration
 	}
 	if(persist === true){
-		apiPersistCache.setItem(key, saltedHam);
+		try{
+			apiPersistCache.setItem(key, saltedHam);
+		}
+		catch(e){
+			if(e.name === "QuotaExceededError"){
+				console.error("Automail: Persistent storage quota exceeded. Attempting to purge expired items.")
+				apiPersistCache.iterate((item, key) => {
+					if(item.time && (NOW() - item.time > item.duration)){
+						apiPersistCache.removeItem(key);
+					}
+				})
+				//apiPersistCache.clear()
+			}
+		}
 	}
 	else{
 		apiCache[key] = saltedHam;

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -288,6 +288,9 @@ if(window.BroadcastChannel){
 			else if(message.data.type === "cachev2"){
 				cache.updateIfDifferent(message.data.mediaData,true)
 			}
+			else if(message.data.type === "cachev3"){
+				apiCache[message.data.key] = message.data.value
+			}
 			else if(message.data.type === "sessionToken"){
 				window.al_token = message.data.value
 				//to prevent "session expired" messages
@@ -698,6 +701,7 @@ function saveCache(data, key, duration, persist){
 	}
 	else{
 		apiCache[key] = saltedHam;
+		aniCast.postMessage({type:"cachev3",key:key,value:saltedHam})
 	}
 }
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -648,20 +648,21 @@ class QueryArgs{
 
 class QueryOptions{
 	constructor(query, variables, auth){
-		function isAuth(){
-			if(auth === true && useScripts.accessToken) return "Bearer " + useScripts.accessToken
-			return null
-		}
 		this.method = "POST",
-		this.headers = {
-			"Authorization": isAuth(),
+		this.headers = new Headers({
 			"Content-Type": "application/json",
 			"Accept": "application/json"
-		},
+		}),
 		this.body = JSON.stringify({
 			"query": query,
 			"variables": variables
 		})
+		this.#isAuth(auth)
+	}
+	#isAuth(auth){
+		if(auth === true && useScripts.accessToken){
+			this.headers.set("Authorization", "Bearer " + useScripts.accessToken)
+		}
 	}
 }
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -745,7 +745,7 @@ async function saveCache(key, data, duration){
 		if(e.name === "QuotaExceededError"){
 			console.error("Persistent storage quota exceeded. Attempting to purge expired items.")
 			try{
-				return await flushCache()
+				return flushCache();
 			}
 			catch(e){
 				throw new Error(e)
@@ -777,7 +777,7 @@ async function updateCache(key, newData){
 			if(e.name === "QuotaExceededError"){
 				console.error("Persistent storage quota exceeded. Attempting to purge expired items.")
 				try{
-					return await flushCache()
+					return flushCache();
 				}
 				catch(e){
 					throw new Error(e)
@@ -825,7 +825,7 @@ async function anilistAPI(query, queryArgs){
 				"errors": [{"message": "Too Many Requests.","status": 429}]
 			};
 		}
-		apiResetLimit = null;
+		apiResetLimit = undefined;
 	}
 	if(args.internal === true){
 		apiUrl = "https://anilist.co/graphql";

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -646,13 +646,12 @@ class QueryArgs{
 		this.auth = false;
 		this.persist = false;
 		this.internal = false;
-		this.schema = "default";
 		Object.assign(this, args);
 	}
 }
 
 class QueryOptions{
-	constructor(query, variables, auth, internal, schema){
+	constructor(query, variables, auth, internal){
 		this.method = "POST",
 		this.headers = new Headers({
 			"Content-Type": "application/json",
@@ -663,17 +662,17 @@ class QueryOptions{
 			"variables": variables
 		})
 		this.#isAuth(auth)
-		this.#isInternal(internal, schema)
+		this.#isInternal(internal)
 	}
 	#isAuth(auth){
 		if(auth === true && useScripts.accessToken){
 			this.headers.set("Authorization", "Bearer " + useScripts.accessToken)
 		}
 	}
-	#isInternal(internal, schema){
+	#isInternal(internal){
 		if(internal === true){
 			if(al_token) this.headers.set("x-csrf-token", al_token)
-			this.headers.set("schema", schema)
+			this.headers.set("schema", "internal")
 		}
 	}
 }
@@ -732,7 +731,7 @@ async function anilistAPI(query, args){
 	if(!query) throw new Error("No query provided")
 	let apiUrl = url;
 	const queryArgs = new QueryArgs(args);
-	const options = new QueryOptions(query, queryArgs.variables, queryArgs.auth, queryArgs.internal, queryArgs.schema);
+	const options = new QueryOptions(query, queryArgs.variables, queryArgs.auth, queryArgs.internal);
 	if(queryArgs.cacheKey && !queryArgs.overWrite){
 		const cache = await checkCache(queryArgs.cacheKey, queryArgs.persist);
 		if(cache) return cache;

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -709,6 +709,14 @@ async function checkCache(key){
 	return null;
 }
 
+function flushCache(){
+	return apiCache.iterate((item, key) => {
+		if(NOW() > item.expiresAt){
+			apiCache.removeItem(key);
+		}
+	})
+}
+
 /**
  * Saves data to the API cache
  * @param {string} key - The key used to store the data.
@@ -728,11 +736,7 @@ function saveCache(key, data, duration){
 		if(e.name === "QuotaExceededError"){
 			console.error("Persistent storage quota exceeded. Attempting to purge expired items.")
 			try{
-				apiCache.iterate((item, key) => {
-					if(NOW() > item.expiresAt){
-						apiCache.removeItem(key);
-					}
-				})
+				flushCache()
 			}
 			catch(e){
 				throw new Error(e)
@@ -764,11 +768,7 @@ async function updateCache(key, newData){
 			if(e.name === "QuotaExceededError"){
 				console.error("Persistent storage quota exceeded. Attempting to purge expired items.")
 				try{
-					return apiCache.iterate((item, key) => {
-						if(NOW() > item.expiresAt){
-							apiCache.removeItem(key);
-						}
-					});
+					return flushCache()
 				}
 				catch(e){
 					throw new Error(e)

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -729,14 +729,14 @@ async function flushCache(){
  * Saves data to the API cache
  * @param {string} key - The key used to store the data.
  * @param {object} data - The data to store.
- * @param {number} [duration] - The length of time to store in seconds.
+ * @param {number} [duration] - The length of time to store in milliseconds.
  * @return {Promise}
  */
 async function saveCache(key, data, duration){
 	const saltedHam = {
 		data: data,
 		createdAt: NOW(),
-		expiresAt: duration ? NOW() + duration*1000 : undefined
+		expiresAt: duration ? NOW() + duration : undefined
 	};
 	try{
 		return apiCache.setItem(key, saltedHam);
@@ -799,7 +799,7 @@ async function updateCache(key, newData){
  * @param {object} [queryArgs] - An object containing request parameters. (e.g. GraphQL variables)
  * @param {object} [queryArgs.variables] - GraphQL variables.
  * @param {string} [queryArgs.cacheKey] - A key used to cache API data.
- * @param {number} [queryArgs.duration] - How long data should remain cached (in seconds.)
+ * @param {number} [queryArgs.duration] - How long data should remain cached (in milliseconds.)
  * @param {boolean} [queryArgs.overwrite] - Ignore cached data when making a request.
  * @param {boolean} [queryArgs.auth] - Make an authenticated request as the current user.
  * @param {boolean} [queryArgs.internal] - Make an internal request. Only uses the internal schema.

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -799,7 +799,7 @@ async function updateCache(key, newData){
  * @param {boolean} [queryArgs.overwrite] - Ignore cached data when making a request.
  * @param {boolean} [queryArgs.auth] - Make an authenticated request as the current user.
  * @param {boolean} [queryArgs.internal] - Make an internal request. Only uses the internal schema.
- * @returns {Promise<object|null>} Response data from the API, cached data, or nothing.
+ * @returns {Promise<object>} Response data from the API or cached data.
  */
 async function anilistAPI(query, queryArgs){
 	if(!query){
@@ -816,7 +816,10 @@ async function anilistAPI(query, queryArgs){
 	}
 	if(apiResetLimit){
 		if(NOW() < apiResetLimit*1000){
-			return null;
+			return {
+				"data": null,
+				"errors": [{"message": "Too Many Requests.","status": 429}]
+			};
 		}
 		apiResetLimit = null;
 	}

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -848,21 +848,18 @@ async function anilistAPI(query, queryArgs){
 	return data;
 }
 
-/**
- * Runs an API cache checkup weekly
- * @returns {Promise|null}
- */
-const cacheCheckup = async () => {
+/** Runs an API cache checkup weekly */
+const cacheCheckup = () => {
 	const check = localStorage.getItem("automail-db-check")
 	if(check){
 		if(NOW() > check){
 			localStorage.setItem("automail-db-check", NOW()+7*24*60*60*1000)
-			return await flushCache();
+			flushCache();
 		}
-		return null;
 	}
-	localStorage.setItem("automail-db-check", NOW()+7*24*60*60*1000)
-	return null;
+	else{
+		localStorage.setItem("automail-db-check", NOW()+7*24*60*60*1000)
+	}
 };
 cacheCheckup()
 //end api v2

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -694,7 +694,7 @@ async function checkCache(key){
 	return null;
 }
 
-function saveCache(data, key, duration){
+function saveCache(key, data, duration){
 	const saltedHam = {
 		data: data,
 		createdAt: NOW(),
@@ -713,6 +713,20 @@ function saveCache(data, key, duration){
 			})
 			//apiCache.clear()
 		}
+	}
+}
+
+async function updateCache(key, newData){
+	const data = await apiCache.getItem(key);
+	if(data){
+		Object.assign(data, {
+			data: newData,
+			updatedAt: NOW()
+		});
+		return apiCache.setItem(key, data);
+	}
+	else{
+		throw new Error(`Key ${key} does not exist in cache.`)
 	}
 }
 
@@ -745,7 +759,7 @@ async function anilistAPI(query, queryArgs){
 	const data = await res.json();
 	if(res.ok){
 		if(args.cacheKey){
-			saveCache(data, args.cacheKey, args.duration);
+			saveCache(args.cacheKey, data, args.duration);
 		}
 		return data;
 	}


### PR DESCRIPTION
This creates a new Anilist api wrapper that could replace the existing `generalAPIcall` and `authAPIcall` functions. The existing wrapper requires the use of many nested callbacks when creating multiple requests leading to code that becomes difficult to read/understand (imo).

I figured it wouldn't be worthwhile to change the existing wrapper and instead wrote a new one in parallel, that does not depend on the existing implementation. It's not a drop-in replacement, so module code would have to be reworked to use it (somewhat similar to the `exportModule` migration.)

A few differences introduced with `anilistAPI`:
- Asynchronous
- Request options are sent in a single argument
- Added authentication as an option
- Added internal api as an option
- Cache backed by localforage
- Rate limiting

It should be feature-complete with the exception of a `queryPacker` replacement, though I plan on doing this at some point. I've added some JSDoc-style documentation that should provide a brief explanation of the new functions.

---
Usage comparison:

Old
```js
generalAPIcall(
  "query($id:Int){Media(id:$id){title {userPreferred} type startDate{year} }}",
  {id: 132473},
  function(data){
    if(!data){
      return
    }
    if(data.data.Media.startDate.year < 2000){
      authAPIcall(
        "mutation($id:Int){SaveMediaListEntry(mediaId:$id,status:PLANNING)}",
          {id: 132473},
          function(data){
            if(!data){
              return
            }
            someCallback(data.data)
          }
      )
    }
  },
  "hohMediaThing" + 132473,10*60*1000,true
)
```
New
```js
const {data, errors} = await anilistAPI("query($id:Int){Media(id:$id){title {userPreferred} type startDate{year} }}", {
  variables: {id: 132473},
  cacheKey: "mediaThing" + 132473,
  duration: 10*60
})
if(errors){
  return
}
if(data.Media.startDate.year < 2000){
  const {data, errors} = await anilistAPI("mutation($id:Int){SaveMediaListEntry(mediaId:$id,status:PLANNING)}", {
    variables: {id: 132473},
    auth: true
  })
  if(errors){
    return
  }
  return data
}
return
```
