### PR TITLE
feedListLikes: fix type issue

### DIFF
--- a/src/modules/feedListLikes.js
+++ b/src/modules/feedListLikes.js
@@ -15,7 +15,7 @@ let likeLoop = setInterval(function(){
 			if(!thingy.querySelector(".count")){
 				return
 			}
-			let likeCount = parseInt(thingy.querySelector(".count").innerText);
+			let likeCount = parseInt(thingy.querySelector(".count").innerText) || 0;
 			if(likeCount <= 5){
 				return
 			}


### PR DESCRIPTION
In certain cases where an activity's like count is 0, the count element is empty and gets parsed improperly. This would lead to the script continuing to run every time the like area was hovered over and consequently several duplicate requests spammed the api. 