### PR TITLE
Add eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# Third-party code
+/src/utilities/localforage.js
+/src/utilities/showdown.js
+/src/purify.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
         "es2017": true,
         "greasemonkey": true
     },
-    "extends": "eslint:recommended",
+    "extends": ["eslint:recommended", "plugin:compat/recommended"],
     "parserOptions": {
         "ecmaVersion": 9
     },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,5 +13,12 @@
         "no-undef": "off",
         "no-extra-semi": "warn",
         "no-useless-escape": "warn"
+    },
+    "settings": {
+        "polyfills": [
+            "String.prototype.includes",
+            "BroadcastChannel",
+            "Array.prototype.flat"
+        ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+    "env": {
+        "browser": true,
+        "es2017": true,
+        "greasemonkey": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 9
+    },
+    "rules": {
+        "no-unused-vars": "off",
+        "no-undef": "off",
+        "no-extra-semi": "warn",
+        "no-useless-escape": "warn"
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es2017": true,
@@ -13,6 +14,11 @@
         "no-undef": "off",
         "no-extra-semi": "warn",
         "no-useless-escape": "warn"
+    },
+    "globals": {
+        "DOMPurify": "readonly",
+        "localforage": "readonly",
+        "showdown": "readonly"
     },
     "settings": {
         "polyfills": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 src/build/
 automail.zip
+node_modules
+package-lock.json
+yarn.lock
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "automail",
+  "version": "10.0.0",
+  "description": "An enhancement collection for anilist.co",
+  "author": "hoh",
+  "license": "GPL-3.0-or-later",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hohMiyazawa/Automail.git"
+  },
+  "bugs": {
+    "url": "https://github.com/hohMiyazawa/Automail/issues"
+  },
+  "homepage": "https://github.com/hohMiyazawa/Automail",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "homepage": "https://github.com/hohMiyazawa/Automail",
   "scripts": {
-    "test": "eslint \"src/build/automail.js\""
+    "lint": "eslint --ignore-pattern \"src/build/automail.js\" \"**/*.js\"",
+    "lint-build": "eslint src/build/automail.js"
   },
   "devDependencies": {
     "eslint": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,14 @@
     "test": "eslint \"src/build/automail.js\""
   },
   "devDependencies": {
-    "eslint": "^8.6.0"
-  }
+    "eslint": "^8.6.0",
+    "eslint-plugin-compat": "^4.0.1"
+  },
+  "browserslist": [
+    "Edge >= 79",
+    "Firefox >= 78",
+    "Chrome >= 64",
+    "Safari >= 12",
+    "Opera >= 51"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/hohMiyazawa/Automail",
   "scripts": {
     "lint": "eslint --ignore-pattern \"src/build/automail.js\" \"**/*.js\"",
-    "lint-build": "eslint src/build/automail.js"
+    "lint-build": "eslint --rule \"no-unused-vars: warn\" --rule \"no-undef: warn\" src/build/automail.js"
   },
   "devDependencies": {
     "eslint": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   },
   "homepage": "https://github.com/hohMiyazawa/Automail",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint \"src/build/automail.js\""
+  },
+  "devDependencies": {
+    "eslint": "^8.6.0"
   }
 }


### PR DESCRIPTION
Fixes #137 

- initialized a Node.js project
- added [eslint](https://github.com/eslint/eslint) and [eslint-plugin-compat](https://github.com/amilajack/eslint-plugin-compat) for linting

How to use:
1. Install [Node.js](https://nodejs.org/en/) LTS for your platform
2. Open terminal and enter the Automail directory
3. Run `npm install`
4. Run `npm run lint` to lint all JS project files
    - Or `npm run lint-build` to lint just the compiled userscript

Installing globally (alternative):
Follow the same steps as above, except replace step 3 with:
- Run `npm install -g eslint@8 eslint-plugin-compat@4`

Optional:
- Install an [integration](https://eslint.org/docs/user-guide/integrations#editors) for your code editor
  - will apply linting as you edit open files instead of needing to run the terminal command

---

There were a lot of false positives because the linter isn't aware that separate modules can access shared top-level variables in the final build. So I disabled the following rules:
- [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars#disallow-unused-variables-no-unused-vars)
- [no-undef](https://eslint.org/docs/rules/no-undef#disallow-undeclared-variables-no-undef)

The config can be changed further if we want to enforce a style guide later.

There's also a small issue with third-party code like localforage which have their own eslint inline comments spread throughout that can throw errors currently.

The default settings from browserslist weren't acceptable to use, so I set minimum browser versions based on their support for es9 using data from [caniuse](https://caniuse.com/sr_es9).