### PR TITLE
Fix enhanced notifications for deleted media

### DIFF
--- a/src/modules/enhanceNotifications.js
+++ b/src/modules/enhanceNotifications.js
@@ -761,14 +761,16 @@ You can also turn off this notice there.`,setting)
 		){
 			//TODO replace this with document.querySelector?
 			const info = notification.children[1].children[0].children[0];
-			active.directLink = info.href
+			if(info.href){
+				active.directLink = info.href
+				let linkMatch =     info.href.match(/activity\/(\d+)/);
+				if(linkMatch){
+					active.link = linkMatch[1]
+				}
+			}
 			active.text =       info.innerHTML;//does not depend on user input
 			active.textName =   (info.childNodes[0] || {textContent: ""}).textContent.trim();
 			active.textSpan =   (info.childNodes[1] || {textContent: ""}).textContent;
-			let linkMatch =     info.href.match(/activity\/(\d+)/);
-			if(linkMatch){
-				active.link = linkMatch[1]
-			};
 			let testType = info.children[0].textContent;
 			active.type = activityTypes[testType];
 			if(!active.type){


### PR DESCRIPTION
related to #110 

it was breaking on a notification about a deleted media (which has no link element so therefore no `href`)

so it's kinda working now...
![](https://share.wildbook.me/kD2TEYl7gZhBepb9.png)
idk what to do about the essays though