### PR TITLE
character/characterBrowse: upgrade to api v2

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -144,12 +144,6 @@ function handleScripts(url,oldUrl){
 		}
 	}
 	else if(
-		url.match(/^https:\/\/anilist\.co\/character\/.*/)
-		&& useScripts.characterFavouriteCount
-	){
-		enhanceCharacter()
-	}
-	else if(
 		url.match(/^https:\/\/anilist\.co\/studio\/.*/)
 	){
 		if(useScripts.studioFavouriteCount){

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -47,13 +47,6 @@ m4_include(css/notifications.css)
 	color: rgb(var(--color-text));
 	font-weight: 500;
 }
-#hohFavCount{
-	position: absolute;
-	right: 30px;
-	color: rgba(var(--color-red));
-	top: 10px;
-	font-weight: 400;
-}
 .hohSlidePlayer{
 	display: block;
 	position: relative;

--- a/src/modules/addReviewConfidence.js
+++ b/src/modules/addReviewConfidence.js
@@ -11,18 +11,6 @@ exportModule({
 		let pageCount = 0;
 		const adultContent = userObject ? userObject.options.displayAdultContent : false;
 
-		function watchElem(selector, parent) {
-			return new Promise(resolve => {
-				new MutationObserver((_mutations, observer) => {
-					const elem = (parent || document).querySelector(selector);
-					if (elem) {
-						observer.disconnect()
-						resolve(elem)
-					}
-				}).observe(parent || document.body, { subtree: true, childList: true })
-			})
-		}
-
 		const addReviewConfidence = async function(){
 			pageCount++
 			const {data, errors} = await anilistAPI("query($page:Int){Page(page:$page,perPage:30){reviews(sort:ID_DESC){id rating ratingAmount}}}", {

--- a/src/modules/character.js
+++ b/src/modules/character.js
@@ -2,34 +2,25 @@ async function enhanceCharacter(){//adds an exact favourite count on every chara
 	if(!location.pathname.match(/^\/character(\/.*)?/)){
 		return
 	}
-	let favCallback = function(data){
-		let adder = function(){
-			if(!document.URL.match(/^https:\/\/anilist\.co\/character\/.*/)){
-				return
-			}
-			let favCount = document.querySelector(".favourite .count");
-			if(favCount){
-				favCount.parentNode.onclick = function(){
-					if(favCount.parentNode.classList.contains("isFavourite")){
-						favCount.innerText = Math.max(parseInt(favCount.innerText) - 1,0)//0 or above, just to avoid looking silly
-					}
-					else{
-						favCount.innerText = parseInt(favCount.innerText) + 1
-					}
-				};
-				if(data.Character.favourites === 0 && favCount[0].classList.contains("isFavourite")){//safe to assume
-					favCount.innerText = data.Character.favourites + 1
-				}
-				else{
-					favCount.innerText = data.Character.favourites
-				}
+	const favWrap = document.querySelector(".favourite") || await watchElem(".favourite");
+	const favCount = favWrap.querySelector(".count");
+	if(!favCount){
+		return;
+	}
+	if(!isNaN(favCount.textContent)){
+		return; // abort early since the site already displays exact fav count if under 1000
+	}
+	const favCallback = function(data){
+		favWrap.onclick = function(){
+			if(favWrap.classList.contains("isFavourite")){
+				favCount.textContent = parseInt(favCount.textContent) - 1;
 			}
 			else{
-				setTimeout(adder,200)
+				favCount.textContent = parseInt(favCount.textContent) + 1;
 			}
 		};
 		if(data.Character.favourites){
-			adder()
+			favCount.textContent = data.Character.favourites;
 		}
 	};
 	const query = `query($id: Int!){
@@ -37,7 +28,7 @@ async function enhanceCharacter(){//adds an exact favourite count on every chara
 			favourites
 		}
 	}`;
-	const variables = {id: parseInt(document.URL.match(/\/character\/(\d+)\/?/)[1])};
+	const variables = {id: parseInt(location.pathname.match(/\/character\/(\d+)\/?/)[1])};
 	const {data, errors} = await anilistAPI(query, {
 		variables,
 		cacheKey: "hohCharacterFavs" + variables.id,

--- a/src/modules/character.js
+++ b/src/modules/character.js
@@ -8,8 +8,9 @@ exportModule({
 		return /^https:\/\/anilist\.co\/character(\/.*)?/.test(url)
 	},
 	code: async function(){
-		const favWrap = document.querySelector(".favourite") || await watchElem(".favourite");
-		const favCount = favWrap.querySelector(".count");
+		const charWrap = document.querySelector(".character");
+		const favWrap = charWrap.querySelector(".favourite") || await watchElem(".favourite", charWrap);
+		const favCount = favWrap.querySelector(".count") || await watchElem(".count", favWrap);
 		if(!favCount){
 			return;
 		}

--- a/src/modules/character.js
+++ b/src/modules/character.js
@@ -1,41 +1,48 @@
-async function enhanceCharacter(){//adds an exact favourite count on every character page
-	if(!location.pathname.match(/^\/character(\/.*)?/)){
-		return
-	}
-	const favWrap = document.querySelector(".favourite") || await watchElem(".favourite");
-	const favCount = favWrap.querySelector(".count");
-	if(!favCount){
-		return;
-	}
-	if(!isNaN(favCount.textContent)){
-		return; // abort early since the site already displays exact fav count if under 1000
-	}
-	const favCallback = function(data){
-		favWrap.onclick = function(){
-			if(favWrap.classList.contains("isFavourite")){
-				favCount.textContent = parseInt(favCount.textContent) - 1;
-			}
-			else{
-				favCount.textContent = parseInt(favCount.textContent) + 1;
+exportModule({
+	id: "characterFavouriteCount",
+	description: "Add an exact favourite count to character pages",
+	isDefault: true,
+	categories: ["Media"],
+	visible: false,
+	urlMatch: function(url){
+		return /^https:\/\/anilist\.co\/character(\/.*)?/.test(url)
+	},
+	code: async function(){
+		const favWrap = document.querySelector(".favourite") || await watchElem(".favourite");
+		const favCount = favWrap.querySelector(".count");
+		if(!favCount){
+			return;
+		}
+		if(!isNaN(favCount.textContent)){
+			return; // abort early since the site already displays exact fav count if under 1000
+		}
+		const favCallback = function(data){
+			favWrap.onclick = function(){
+				if(favWrap.classList.contains("isFavourite")){
+					favCount.textContent = parseInt(favCount.textContent) - 1;
+				}
+				else{
+					favCount.textContent = parseInt(favCount.textContent) + 1;
+				}
+			};
+			if(data.Character.favourites){
+				favCount.textContent = data.Character.favourites;
 			}
 		};
-		if(data.Character.favourites){
-			favCount.textContent = data.Character.favourites;
+		const query = `query($id: Int!){
+			Character(id: $id){
+				favourites
+			}
+		}`;
+		const variables = {id: parseInt(location.pathname.match(/\/character\/(\d+)\/?/)[1])};
+		const {data, errors} = await anilistAPI(query, {
+			variables,
+			cacheKey: "hohCharacterFavs" + variables.id,
+			duration: 60*60*1000
+		});
+		if(errors){
+			return;
 		}
-	};
-	const query = `query($id: Int!){
-		Character(id: $id){
-			favourites
-		}
-	}`;
-	const variables = {id: parseInt(location.pathname.match(/\/character\/(\d+)\/?/)[1])};
-	const {data, errors} = await anilistAPI(query, {
-		variables,
-		cacheKey: "hohCharacterFavs" + variables.id,
-		duration: 60*60*1000
-	});
-	if(errors){
-		return;
+		return favCallback(data);
 	}
-	return favCallback(data);
-}
+})

--- a/src/modules/character.js
+++ b/src/modules/character.js
@@ -1,11 +1,10 @@
-function enhanceCharacter(){//adds a favourite count on every character page
+async function enhanceCharacter(){//adds an exact favourite count on every character page
 	if(!location.pathname.match(/^\/character(\/.*)?/)){
 		return
 	}
 	if(document.getElementById("hohFavCount")){
 		return
 	}
-	let oldData = false;
 	let favCallback = function(data){
 		let adder = function(){
 			if(!document.URL.match(/^https:\/\/anilist\.co\/character\/.*/)){
@@ -21,31 +20,34 @@ function enhanceCharacter(){//adds a favourite count on every character page
 						favCount.innerText = parseInt(favCount.innerText) + 1
 					}
 				};
-				if(data.data.Character.favourites === 0 && favCount[0].classList.contains("isFavourite")){//safe to assume
-					favCount.innerText = data.data.Character.favourites + 1
+				if(data.Character.favourites === 0 && favCount[0].classList.contains("isFavourite")){//safe to assume
+					favCount.innerText = data.Character.favourites + 1
 				}
 				else{
-					favCount.innerText = data.data.Character.favourites
+					favCount.innerText = data.Character.favourites
 				}
 			}
 			else{
 				setTimeout(adder,200)
 			}
 		};
-		if(data.data.Character.favourites){
+		if(data.Character.favourites){
 			adder()
 		}
 	};
+	const query = `query($id: Int!){
+		Character(id: $id){
+			favourites
+		}
+	}`;
 	const variables = {id: parseInt(document.URL.match(/\/character\/(\d+)\/?/)[1])};
-	generalAPIcall(
-		`query($id: Int!){
-			Character(id: $id){
-				favourites
-			}
-		}`,
+	const {data, errors} = await anilistAPI(query, {
 		variables,
-		favCallback,
-		"hohCharacterFavs" + variables.id + "page1",
-		60*60*1000
-	)
+		cacheKey: "hohCharacterFavs" + variables.id,
+		duration: 60*60*1000
+	});
+	if(errors){
+		return;
+	}
+	return favCallback(data);
 }

--- a/src/modules/character.js
+++ b/src/modules/character.js
@@ -2,9 +2,6 @@ async function enhanceCharacter(){//adds an exact favourite count on every chara
 	if(!location.pathname.match(/^\/character(\/.*)?/)){
 		return
 	}
-	if(document.getElementById("hohFavCount")){
-		return
-	}
 	let favCallback = function(data){
 		let adder = function(){
 			if(!document.URL.match(/^https:\/\/anilist\.co\/character\/.*/)){

--- a/src/modules/characterBrowse.js
+++ b/src/modules/characterBrowse.js
@@ -4,57 +4,56 @@ exportModule({
 	isDefault: true,
 	categories: ["Browse"],
 	visible: false,
-	urlMatch: function(url,oldUrl){
-		return url.match(/^https:\/\/anilist\.co\/search\/characters/)
+	urlMatch: function(url){
+		return /^https:\/\/anilist\.co\/search\/characters\/?(favorites)?$/.test(url)
 	},
-	code: async function(){
-		if(
-			!document.URL.match(/\/search\/characters\/?(favorites)?$/)
-		){
-			return
-		}
+	code: function(){
+		let pageCount = 0;
+		let perPage = 30;
 		const query = `
-query($page: Int!){
-	Page(page: $page,perPage: 20){
+query($page: Int!,$perPage: Int!){
+	Page(page: $page,perPage: $perPage){
 		characters(sort: [FAVOURITES_DESC]){
 			id
 			favourites
 		}
 	}
 }`;
-		let favCallback = async function(data,page){
-			if(!document.URL.match(/\/search\/characters\/?(favorites)?$/)){
-				return
-			}
-			let resultsToTag = document.querySelectorAll(".results.cover .staff-card,.landing-section.characters .staff-card");
-			if(resultsToTag.length < page*data.Page.characters.length){
-				setTimeout(function(){
-					favCallback(data,page)
-				},200);//may take some time to load
-				return;
-			}
-			data = data.Page.characters;
-			data.forEach((character,index) => create(
+		const results = document.querySelector(".landing-section.characters > .results, .results.cover");
+		let charCount = results.childElementCount;
+
+		const insertFavs = function(data){
+			const chars = data.Page.characters;
+			chars.forEach((character,index) => create(
 				"span",
 				"hohFavCountBrowse",
 				character.favourites,
-				resultsToTag[(page - 1)*data.length + index]
+				results.children[(pageCount - 1)*chars.length + index]
 			).title = translate("$characterBrowseTooltip"));
-			const {ndata, errors} = await anilistAPI(query, {
-				variables: {page: page + 1}
+		}
+
+		const getFavs = async function(){
+			pageCount++
+			const {data, errors} = await anilistAPI(query, {
+				variables: {page: pageCount, perPage}
 			})
 			if(errors){
 				return;
 			}
-			return favCallback(ndata, page + 1);
-		};
-		const {data, errors} = await anilistAPI(query, {
-			variables: {page: 1}
-		})
-		if(errors){
-			return;
+			return insertFavs(data);
 		}
-		return favCallback(data, 1);
+
+		if(!/\/search\/characters\/?$/.test(location.pathname)){ // full favorites page
+			perPage = 20;
+			new MutationObserver((_mutations) => {
+				if(results.childElementCount !== charCount && results.childElementCount % 20 === 0){
+					charCount = results.childElementCount;
+					getFavs();
+				}
+			}).observe(results, { subtree: true, childList: true })
+		}
+
+		getFavs();
 	},
 	css: `
 .hohFavCountBrowse{

--- a/src/modules/characterBrowse.js
+++ b/src/modules/characterBrowse.js
@@ -1,6 +1,6 @@
 exportModule({
-	id: "characterFavouriteCount",
-	description: "add fav counts to character browse",
+	id: "characterBrowseFavouriteCount",
+	description: "Add favourite counts to character browse pages",
 	isDefault: true,
 	categories: ["Browse"],
 	visible: false,

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -969,4 +969,22 @@ function cheapReload(linkElement,vueData){
 function hasOwn(obj, prop){
 	return Object.hasOwn ? Object.hasOwn(obj, prop) : Object.prototype.hasOwnProperty.call(obj, prop)
 }
+
+/**
+ * Watch for an element's existence
+ * @param {string} selector
+ * @param {any} [parent]
+ * @returns {Promise<Element>}
+ */
+function watchElem(selector, parent) {
+	return new Promise(resolve => {
+		new MutationObserver((_mutations, observer) => {
+			const elem = (parent || document).querySelector(selector);
+			if (elem) {
+				observer.disconnect()
+				resolve(elem)
+			}
+		}).observe(parent || document.body, { subtree: true, childList: true })
+	})
+}
 //end "utilities.js"


### PR DESCRIPTION
character:
- migrated to module
- removed old references (likely used before the page redesign)
- reworked to run only when the count exceeds 1000 favs
  - prevents extra requests from being sent

characterBrowse:
- reworked to use a MutationObserver to watch for more results loading instead of setTimeout
- fixed an issue where the main browse page didn't load all fav counts
  - main browse loads a single batch of 30, `/favorites` loads batches of 20

utilities:
- moved watchElem here so it can be more widely used