### PR TITLE
filterStaffTabs: visual upgrade

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1772,17 +1772,13 @@ body.TMPreviewScore > .el-tooltip__popper{
 	min-height: 340px;
 }
 #hohStaffTabFilter{
-	display: none;
-	position: absolute;
-	right: 0px;
-	top: -25px;
-}
-.media-staff + #hohStaffTabFilter{
-	display: inline;
+	display: grid;
+	margin-bottom: 15px;
+	grid-template-columns: 1fr 1fr 1fr;
 }
 #hohStaffTabFilter > input{
-	height: 20px;
-	margin-left: 3px;
+	margin-left: 0;
+	grid-column: 3;
 }
 #hohFilterRemover{
 	display: none;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1773,7 +1773,7 @@ body.TMPreviewScore > .el-tooltip__popper{
 #hohStaffTabFilter{
 	display: grid;
 	margin-bottom: 15px;
-	grid-template-columns: 2fr auto 1fr;
+	grid-template-columns: 3fr 30px 1fr;
 }
 #hohStaffTabFilter > input{
 	margin-left: 0;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -317,10 +317,9 @@ m4_include(css/notifications.css)
 }
 [list="staffRoles"]{
 	background: rgb(var(--color-foreground));
-	background: rgb(var(--color-foreground));
-	padding: 5px;
+	padding: 5px 10px;
 	border-width: 0px;
-	border-radius: 2px;
+	border-radius: 3px;
 	margin-left: 20px;
 	color: rgb(var(--color-text));
 }
@@ -1774,7 +1773,7 @@ body.TMPreviewScore > .el-tooltip__popper{
 #hohStaffTabFilter{
 	display: grid;
 	margin-bottom: 15px;
-	grid-template-columns: 1fr 1fr 1fr;
+	grid-template-columns: 2fr auto 1fr;
 }
 #hohStaffTabFilter > input{
 	margin-left: 0;
@@ -1782,6 +1781,8 @@ body.TMPreviewScore > .el-tooltip__popper{
 }
 #hohFilterRemover{
 	display: none;
+	grid-column: 2;
+	padding: 5px 8px;
 }
 #hohFilterRemover:hover{
 	cursor: pointer;

--- a/src/modules/filterStaffTabs.js
+++ b/src/modules/filterStaffTabs.js
@@ -7,84 +7,69 @@ exportModule({
 	urlMatch: function(url,oldUrl){
 		return url.match(/^https:\/\/anilist\.co\/(anime|manga)\/\d+\/.*\/staff/)
 	},
-	code: function(){
-		let waiter = function(tries){
-			if(!document.URL.match(/^https:\/\/anilist\.co\/(anime|manga)\/\d+\/.*\/staff/)){
-				return
-			}
-			if(tries > 10){
-				return
-			}
-			let mediaStaff = document.querySelector(".media-staff");
-			if(!mediaStaff){
-				setTimeout(function(){waiter(0)},250);
-				return
-			}
-			let staffGrid = mediaStaff.querySelector(".grid-wrap");
-			if(staffGrid.children.length > 9){
-				let filterBoxContainer = create("div","#hohStaffTabFilter");
-				mediaStaff.prepend(filterBoxContainer);
-				let filterRemover = create("span","#hohFilterRemover",svgAssets.cross,filterBoxContainer)
-				let filterBox = create("input",false,false,filterBoxContainer);
-				filterBox.placeholder = "Filter by name or role";
-				filterBox.setAttribute("list","staffRoles");
-				let filterer = function(){
-					let val = filterBox.value;
-					Array.from(staffGrid.children).forEach(card => {
-						if(
-							looseMatcher(card.querySelector(".name").innerText,val)
-							|| looseMatcher(card.querySelector(".role").innerText,val)
-						){
-							card.style.display = "inline-grid"
-						}
-						else{
-							card.style.display = "none"
-						}
-					});
-					if(val === ""){
-						filterRemover.style.display = "none"
+	code: async function(){
+		const mediaStaff = document.querySelector(".media-staff") || await watchElem(".media-staff");
+		const staffGrid = mediaStaff.querySelector(".grid-wrap") || await watchElem(".grid-wrap",mediaStaff);
+		if(staffGrid.children.length > 9){
+			let filterBoxContainer = create("div","#hohStaffTabFilter");
+			mediaStaff.prepend(filterBoxContainer);
+			let filterRemover = create("span","#hohFilterRemover",svgAssets.cross,filterBoxContainer)
+			let filterBox = create("input",false,false,filterBoxContainer);
+			filterBox.placeholder = "Filter by name or role";
+			filterBox.setAttribute("list","staffRoles");
+			let filterer = function(){
+				let val = filterBox.value;
+				Array.from(staffGrid.children).forEach(card => {
+					if(
+						looseMatcher(card.querySelector(".name").innerText,val)
+						|| looseMatcher(card.querySelector(".role").innerText,val)
+					){
+						card.style.display = "inline-grid"
 					}
 					else{
-						filterRemover.style.display = "inline"
+						card.style.display = "none"
 					}
-				}
-				filterRemover.onclick = function(){
-					filterBox.value = "";
-					filterer()
-				}
-				filterBox.oninput = filterer;
-				let dataList = create("datalist","#staffRoles",false,filterBoxContainer);
-				let buildStaffRoles = function(){
-					let autocomplete = new Set();
-					Array.from(staffGrid.children).forEach(card => {
-						autocomplete.add(card.querySelector(".name").innerText);
-						autocomplete.add(card.querySelector(".role").innerText.replace(/\s*\(.*\)\.?\s*/,""));
-						if(card.querySelector(".role").innerText.includes("OP")){
-							autocomplete.add("OP")
-						}
-						if(card.querySelector(".role").innerText.includes("ED")){
-							autocomplete.add("ED")
-						}
-					})
-					removeChildren(dataList);
-					autocomplete.forEach(
-						value => create("option",false,false,dataList).value = value
-					)
-				};buildStaffRoles();
-				let mutationConfig = {
-					attributes: false,
-					childList: true,
-					subtree: false
-				};
-				let observer = new MutationObserver(function(){
-					filterer();
-					buildStaffRoles()
 				});
-				observer.observe(staffGrid,mutationConfig)
+				if(val === ""){
+					filterRemover.style.display = "none"
+				}
+				else{
+					filterRemover.style.display = "inline"
+				}
 			}
-			else{
-				setTimeout(function(){waiter(++tries)},250 + tries*100)
+			filterRemover.onclick = function(){
+				filterBox.value = "";
+				filterer()
 			}
-		};waiter(0)
+			filterBox.oninput = filterer;
+			let dataList = create("datalist","#staffRoles",false,filterBoxContainer);
+			let buildStaffRoles = function(){
+				let autocomplete = new Set();
+				Array.from(staffGrid.children).forEach(card => {
+					autocomplete.add(card.querySelector(".name").innerText);
+					autocomplete.add(card.querySelector(".role").innerText.replace(/\s*\(.*\)\.?\s*/,""));
+					if(card.querySelector(".role").innerText.includes("OP")){
+						autocomplete.add("OP")
+					}
+					if(card.querySelector(".role").innerText.includes("ED")){
+						autocomplete.add("ED")
+					}
+				})
+				removeChildren(dataList);
+				autocomplete.forEach(
+					value => create("option",false,false,dataList).value = value
+				)
+			};buildStaffRoles();
+			let mutationConfig = {
+				attributes: false,
+				childList: true,
+				subtree: false
+			};
+			let observer = new MutationObserver(function(){
+				filterer();
+				buildStaffRoles()
+			});
+			observer.observe(staffGrid,mutationConfig)
+		}
 	}
 })

--- a/src/modules/filterStaffTabs.js
+++ b/src/modules/filterStaffTabs.js
@@ -20,15 +20,17 @@ exportModule({
 				setTimeout(function(){waiter(0)},250);
 				return
 			}
-			if(mediaStaff.children[0].children.length > 9){
-				let filterBoxContainer = create("div","#hohStaffTabFilter",false,mediaStaff.parentNode);
+			let staffGrid = mediaStaff.querySelector(".grid-wrap");
+			if(staffGrid.children.length > 9){
+				let filterBoxContainer = create("div","#hohStaffTabFilter");
+				mediaStaff.prepend(filterBoxContainer);
 				let filterRemover = create("span","#hohFilterRemover",svgAssets.cross,filterBoxContainer)
 				let filterBox = create("input",false,false,filterBoxContainer);
-				filterBox.placeholder = translate("$mediaStaff_filter");
+				filterBox.placeholder = "Filter by name or role";
 				filterBox.setAttribute("list","staffRoles");
 				let filterer = function(){
 					let val = filterBox.value;
-					Array.from(mediaStaff.children[0].children).forEach(card => {
+					Array.from(staffGrid.children).forEach(card => {
 						if(
 							looseMatcher(card.querySelector(".name").innerText,val)
 							|| looseMatcher(card.querySelector(".role").innerText,val)
@@ -54,7 +56,7 @@ exportModule({
 				let dataList = create("datalist","#staffRoles",false,filterBoxContainer);
 				let buildStaffRoles = function(){
 					let autocomplete = new Set();
-					Array.from(mediaStaff.children[0].children).forEach(card => {
+					Array.from(staffGrid.children).forEach(card => {
 						autocomplete.add(card.querySelector(".name").innerText);
 						autocomplete.add(card.querySelector(".role").innerText.replace(/\s*\(.*\)\.?\s*/,""));
 						if(card.querySelector(".role").innerText.includes("OP")){
@@ -78,7 +80,7 @@ exportModule({
 					filterer();
 					buildStaffRoles()
 				});
-				observer.observe(mediaStaff.children[0],mutationConfig)
+				observer.observe(staffGrid,mutationConfig)
 			}
 			else{
 				setTimeout(function(){waiter(++tries)},250 + tries*100)


### PR DESCRIPTION
Changed the design to better match the search bar used on staff pages as well as to fit better on the media page itself.
- made use of grid for better positioning on the page
- used `watchElem` to replace the use of the waiter function
- changed the placeholder text to more explicitly describe what can be filtered
  - I didn't change the translation key since it is also being used by the media list filter box (might need to make a new key for that)

Preview:
![](https://x0.at/YXjm.png)

![](https://x0.at/w2Jl.png)