### PR TITLE
anisongs: update animethemes url

### DIFF
--- a/src/modules/anisongs.js
+++ b/src/modules/anisongs.js
@@ -28,7 +28,7 @@ const API = {
     return res.json()
   },
   async getVideos(anilist_id) {
-    const res = await fetch(`https://staging.animethemes.moe/api/anime?filter[has]=resources&filter[site]=AniList&filter[external_id]=${anilist_id}&include=animethemes.animethemeentries.videos`)
+    const res = await fetch(`https://api.animethemes.moe/anime?filter[has]=resources&filter[site]=AniList&filter[external_id]=${anilist_id}&include=animethemes.animethemeentries.videos`)
     return res.json()
   }
 }


### PR DESCRIPTION
The animethemes api is now stable.
(new docs link for reference: https://api-docs.animethemes.moe )