### PR TITLE
Update Advanced Scores tooltip style

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -1086,6 +1086,21 @@ meter::-moz-meter-bar{
 	font-weight: bold;
 	margin-left: 9px;
 }
+.hohAdvancedDollar:hover:before{
+	background: rgba(var(--color-overlay),.9);
+	color: rgb(var(--color-text-bright));
+	content: attr(data-tooltip);
+	position: absolute;
+	margin-left: 30px;
+	margin-top: -8px;
+	padding: 10px;
+	border-radius: 4px;
+	font-weight: normal;
+	font-size: 1.3rem;
+	text-align-last: justify;
+	white-space: pre-line;
+	z-index: 1000;
+}
 .social input[list="socialUsers"]{
 	background: rgb(var(--color-foreground));
 	border-width: 0px;

--- a/src/modules/viewAdvancedScores.js
+++ b/src/modules/viewAdvancedScores.js
@@ -46,7 +46,7 @@ function viewAdvancedScores(url){
 						).filter(
 							a => a[1]
 						);
-						dollar.title = reasonable.map(
+						dollar.dataset.tooltip = reasonable.map(
 							a => a[0] + ": " + a[1]
 						).join("\n");
 						if(!reasonable.length){


### PR DESCRIPTION
Updated the Advanced Scores tooltip style

- Matches other Anilist tooltip styles (notes etc.)
- Tooltip now appears instantly on hover rather than default delayed behaviour
- Added Justify for nicer scoring alignment

Preview:
![image](https://user-images.githubusercontent.com/28376248/199947536-d07d1c0c-0563-47a2-b5c7-935d35296d76.png)