### PR TITLE
eslint: ignore build directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,6 @@
 
 # Code fragments
 /src/queries/
+
+# Build artifacts
+/src/build/

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/hohMiyazawa/Automail",
   "scripts": {
-    "lint": "eslint --ignore-pattern \"src/build/automail.js\" \"**/*.js\"",
-    "lint-build": "eslint --rule \"no-unused-vars: warn\" --rule \"no-undef: warn\" src/build/automail.js"
+    "lint": "eslint \"**/*.js\"",
+    "lint-build": "eslint --rule \"no-unused-vars: warn\" --rule \"no-undef: warn\" --no-ignore src/build/automail.js"
   },
   "devDependencies": {
     "eslint": "^8.6.0",


### PR DESCRIPTION
Ignores other build variants (can be overriden with `--no-ignore` if needed)