### PR TITLE
anilistAPI: adjust rate limit handling

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -921,6 +921,9 @@ async function anilistAPI(query, queryArgs){
 	}
 	catch(e){
 		console.error(e)
+		if(e.message === "NetworkError when attempting to fetch resource."){//assume burst limit has been reached
+			apiResetLimit = (NOW()+60*1000)/1000;
+		}
 		return {
 			"data": null,
 			"errors": [{"message": e,"status": null}]

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -910,7 +910,7 @@ async function anilistAPI(query, queryArgs){
 				}
 				else{
 					apiResetLimit = (NOW()+60*1000)/1000;
-					throw new Error("Exceeded AniList API request limit. Please report the issue at https://github.com/hohMiyazawa/Automail/issues")
+					console.error("Exceeded AniList API burst limit.")
 				}
 			}
 			else if(res.status !== 404){


### PR DESCRIPTION
- Changed to a normal console output as throwing was unnecessary
  - (I was not aware of the burst limit previously and assumed only faulty modules could reach this point)
- Add a reset limit manually if a certain `NetworkError` is received
  - Most likely due to the current state of the server, when the burst limit is reached the api stops sending the right CORS header and ends up creating network errors instead of HTTP errors which contain no useful responses. So until that's resolved I think it's safe to reset the limit whenever this error is caught.