### PR TITLE
Fix dropdown bug for directEditorAccess

### DIFF
--- a/src/modules/directEditorAccess.js
+++ b/src/modules/directEditorAccess.js
@@ -19,7 +19,8 @@ exportModule({
 							if(tmp_target.classList.contains("entry-dropdown")){
 								let item = document.getElementById(tmp_target.children[0].getAttribute("aria-controls"));
 								if(item){
-									item.querySelector(".el-dropdown-menu__item--divided").click()
+									item.querySelector(".el-dropdown-menu__item--divided").click();
+									item.hidden = true
 								}
 								break
 							}


### PR DESCRIPTION
Fixed a visual bug where after the click event, the dropdown box shows up on top of the editor window

Screenshot of bug
![image](https://user-images.githubusercontent.com/28376248/208442578-3c32d3cf-a825-4524-b0c2-4e23ab12beb5.png)
