### PR TITLE
Update hideScores - Add onclick scores, add missing browse, cleanup

### DIFF
--- a/src/modules/hideScores.js
+++ b/src/modules/hideScores.js
@@ -15,74 +15,61 @@ Does not hide scores set by other Automail options
 	code: function(){
 		if(/^\/(anime|manga)\/.*/.test(location.pathname)){
 			let scoreSpoiler = function(){
-				let allNode = Array.from(document.querySelectorAll(".sidebar .data .data-set .type"));
-				if(!allNode){
-					return false
+				let sidebarNode = Array.from(document.querySelectorAll(".sidebar .data .data-set .type"));
+				if(!sidebarNode.length){
+					return
 				};
-				let avgNode = allNode.find(element => element.innerText === "Average Score");
-				if(avgNode){
-					avgNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none; cursor: pointer;";
-					avgNode.parentNode.children[1].onmouseover = function(){
-						this.style.color = 'white'
-					};
-					avgNode.parentNode.children[1].onmouseout = function(){
-						this.style.color = 'transparent'
-					};
-					avgNode.parentNode.children[1].onclick = function(){
-						if(this.onmouseover){
-							this.onmouseover = null;
-							this.onmouseout = null;
-							this.style.color = 'white'
-						}
-						else{
-							this.onmouseover = function(){
+				let scoreNode = new Array();
+				let findAvg = sidebarNode.find(element => element.innerText === "Average Score");
+				let findMean = sidebarNode.find(element => element.innerText === "Mean Score");
+				findAvg && scoreNode.push(findAvg);
+				findMean && scoreNode.push(findMean);
+				if(scoreNode.length){
+					scoreNode.forEach(score => {
+						if(!score.parentNode.children[1].hasAttribute("data-click")){
+							score.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none; cursor: pointer;"
+						};
+						score.parentNode.children[1].onmouseover = function(){
+							if(this.getAttribute("data-click") != "1"){
 								this.style.color = 'white'
-							};
-							this.onmouseout = function(){
+							}
+						};
+						score.parentNode.children[1].onmouseout = function(){
+							if(this.getAttribute("data-click") != "1"){
 								this.style.color = 'transparent'
-							};
-							this.style.color = 'transparent'
-						}
-					}
-				};
-				let meanNode = allNode.find(element => element.innerText === "Mean Score");
-				if(meanNode){
-					meanNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none; cursor: pointer;";
-					meanNode.parentNode.children[1].onmouseover = function(){
-						this.style.color = 'white'
-					};
-					meanNode.parentNode.children[1].onmouseout = function(){
-						this.style.color = 'transparent'
-					}
-					meanNode.parentNode.children[1].onclick = function(){
-						if(this.onmouseover){
-							this.onmouseover = null;
-							this.onmouseout = null;
-							this.style.color = 'white'
-						}
-						else{
-							this.onmouseover = function(){
+							}
+						};
+						score.parentNode.children[1].onclick = function(event){
+							event.stopPropagation();
+							if(!this.hasAttribute("data-click") || this.getAttribute("data-click") == "0"){
+								this.onmouseover = null;
+								this.onmouseout = null;
+								this.setAttribute("data-click","1");
 								this.style.color = 'white'
-							};
-							this.onmouseout = function(){
+							}
+							else{
+								this.onmouseover = function(){
+									this.style.color = 'white'
+								};
+								this.onmouseout = function(){
+									this.style.color = 'transparent'
+								};
+								this.setAttribute("data-click","0");
 								this.style.color = 'transparent'
-							};
-							this.style.color = 'transparent'
+							}
 						}
-					}
-				};
-				return (avgNode && meanNode ? true : false)
+					})
+				}
 			};
+			scoreSpoiler();
 			let mutationConfig = {
 				attributes: false,
 				childList: true,
 				subtree: true
 			};
-			let observer = new MutationObserver(function(){
-				scoreSpoiler() && observer.disconnect()
-			});
-			!scoreSpoiler() && observer.observe(document.body,mutationConfig)
-		}
+			let observer = new MutationObserver(scoreSpoiler);
+			observer.observe(document.body,mutationConfig);
+		};
 		if(/^\/home\/?$/.test(location.pathname) || /^\/forum\/thread\/.*/.test(location.pathname) || /^\/user\/.*/.test(location.pathname)){
 			let removeEmbedScore = function(){
 				let embed = Array.from(document.querySelectorAll(".embed .wrap .info"));
@@ -111,18 +98,18 @@ Does not hide scores set by other Automail options
 	.overview .media-score-distribution:not(:hover){
 		background-color: rgba(var(--color-black),0.5);
 	}
-	.overview .media-score-distribution .ct-chart-bar:not(:hover), .media-card .score, .overview .follow .score:not(:hover){
+	.overview .media-score-distribution .ct-chart-bar:not(:hover), .media-card .hover-data .score, .overview .follow .score:not(:hover), .table .media-card .score .icon:not(:hover), .media-card .data .score .icon:not(:hover){
 		opacity: 0;
 		user-select: none;
 	}
-	.overview .follow span{
+	.overview .follow span, .table .media-card .score .percentage, .table .media-card .score .popularity, .media-card .data .score, .media-card .data .score .percentage{
 		text-align: center;
 		border-radius: 3px;
 		background-color: rgba(var(--color-black),0.5);
 		color: white;
 		user-select: none;
 	}
-	.overview .follow span:not(:hover){
+	.overview .follow span:not(:hover), .table .media-card .score .percentage:not(:hover), .table .media-card .score .popularity:not(:hover), .media-card .data .score .percentage:not(:hover){
 		color: transparent;
 	}
 	`

--- a/src/modules/hideScores.js
+++ b/src/modules/hideScores.js
@@ -54,7 +54,7 @@ Does not hide scores set by other Automail options
 					meanNode.parentNode.children[1].onmouseout = function(){
 						this.style.color = 'transparent'
 					}
-                    meanNode.parentNode.children[1].onclick = function(){
+					meanNode.parentNode.children[1].onclick = function(){
 						if(this.onmouseover){
 							this.onmouseover = null;
 							this.onmouseout = null;

--- a/src/modules/hideScores.js
+++ b/src/modules/hideScores.js
@@ -21,22 +21,54 @@ Does not hide scores set by other Automail options
 				};
 				let avgNode = allNode.find(element => element.innerText === "Average Score");
 				if(avgNode){
-					avgNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none;";
+					avgNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none; cursor: pointer;";
 					avgNode.parentNode.children[1].onmouseover = function(){
 						this.style.color = 'white'
 					};
 					avgNode.parentNode.children[1].onmouseout = function(){
 						this.style.color = 'transparent'
+					};
+					avgNode.parentNode.children[1].onclick = function(){
+						if(this.onmouseover){
+							this.onmouseover = null;
+							this.onmouseout = null;
+							this.style.color = 'white'
+						}
+						else{
+							this.onmouseover = function(){
+								this.style.color = 'white'
+							};
+							this.onmouseout = function(){
+								this.style.color = 'transparent'
+							};
+							this.style.color = 'transparent'
+						}
 					}
 				};
 				let meanNode = allNode.find(element => element.innerText === "Mean Score");
 				if(meanNode){
-					meanNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none;";
+					meanNode.parentNode.children[1].style = "background-color: rgba(var(--color-black),0.5); color: transparent; padding: 0px 10px; border-radius: 3px; user-select: none; cursor: pointer;";
 					meanNode.parentNode.children[1].onmouseover = function(){
 						this.style.color = 'white'
 					};
 					meanNode.parentNode.children[1].onmouseout = function(){
 						this.style.color = 'transparent'
+					}
+                    meanNode.parentNode.children[1].onclick = function(){
+						if(this.onmouseover){
+							this.onmouseover = null;
+							this.onmouseout = null;
+							this.style.color = 'white'
+						}
+						else{
+							this.onmouseover = function(){
+								this.style.color = 'white'
+							};
+							this.onmouseout = function(){
+								this.style.color = 'transparent'
+							};
+							this.style.color = 'transparent'
+						}
 					}
 				};
 				return (avgNode && meanNode ? true : false)
@@ -76,6 +108,9 @@ Does not hide scores set by other Automail options
 		}
 	},
 	css: `
+	.overview .media-score-distribution:not(:hover){
+		background-color: rgba(var(--color-black),0.5);
+	}
 	.overview .media-score-distribution .ct-chart-bar:not(:hover), .media-card .score, .overview .follow .score:not(:hover){
 		opacity: 0;
 		user-select: none;


### PR DESCRIPTION
Added ability to click Avg/Mean scores on media pages to get them to stay displayed. 
Added/updated additional css for other browse views. Now applies to all 3 views - Compact cards (Hidden), expanded cards (spoiler), list rows (spoiler).
Cleaned up/simplified code.

There is a small bug on some media (eg. CSM for me) where the `.overview .follow .score` style color is being overridden by another module so text always shows. Not sure what to do about it so for now left it at opacity: 0 on no hover.
![image](https://user-images.githubusercontent.com/28376248/210485026-a7be44f5-5192-40b1-8ac4-90705e728cfd.png)