### PR TITLE
Add module altBanner

### DIFF
--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -1,8 +1,8 @@
 exportModule({
 	id: "altBanner",
-	description: "Alternative banner style on media pages for wider resolutions",
+	description: "Alternative banner style on media pages for wider screen resolutions",
 	extendedDescription: `
-Prevents the banner on media pages from stretching and cropping on resolutions wider than 1920 pixels
+Prevents the banner on media pages from stretching and cropping on screen resolutions wider than 1920 pixels
 Instead, it always displays the banner in full with sides filled in by the blurred original banner
 	`,
 	isDefault: false,

--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -43,7 +43,7 @@ Instead, it always displays the banner in full with sides filled in by the blurr
 		z-index: -2;
 	}
 	.blur-filter::after{
-		backdrop-filter: blur(5px);
+		backdrop-filter: blur(10px);
 		content: "";
 		display: block;
 		position: absolute;

--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -1,0 +1,63 @@
+exportModule({
+	id: "altBanner",
+	description: "Alternative banner style on media pages for wider resolutions",
+	extendedDescription: `
+Prevents the banner on media pages from stretching and cropping on resolutions wider than 1920 pixels
+Instead, it always displays the banner in full with sides filled in by the blurred original banner
+	`,
+	isDefault: false,
+	importance: 0,
+	categories: ["Media","Newly Added"],
+	visible: true,
+	urlMatch: function(url){
+		return /^https:\/\/anilist\.co\/(anime|manga)\/.*/.test(url)
+	},
+	code: function(){
+		let banner;
+		let adder = function(mutations, observer){
+			banner = document.querySelector(".media .banner");
+			if(!banner){
+				return
+			};
+			if(banner){
+				observer && observer.disconnect();
+				banner.classList.add("blur-filter");
+				let bannerFull = create("img","altBanner",null,banner);
+				bannerFull.height = "400";
+				bannerFull.src = banner.style.backgroundImage.replace("url(","").replace(")","").replace('"',"").replace('"',"")
+			}
+		};
+		adder();
+		let mutationConfig = {
+			attributes: false,
+			childList: true,
+			subtree: true
+		};
+		let observer = new MutationObserver(adder);
+		!banner && observer.observe(document.body,mutationConfig)
+	},
+	css: `
+	.media .banner{
+		margin-top: 0px !important;
+		position: relative;
+		z-index: -2;
+	}
+	.blur-filter::after {
+		backdrop-filter: blur(5px);
+		content: "";
+		display: block;
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		top: 0;
+		z-index: -2;
+	}
+	.altBanner{
+		position: absolute;
+		top: 0;
+		left: 50%;
+		transform: translate(-50%);
+		z-index: -1;
+	}
+	`
+})

--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -1,8 +1,8 @@
 exportModule({
 	id: "altBanner",
-	description: "Alternative banner style on media pages for wider screen resolutions",
+	description: "Alternative banner style on media pages for wider resolutions",
 	extendedDescription: `
-Prevents the banner on media pages from stretching and cropping on screen resolutions wider than 1920 pixels
+Prevents the banner on media pages from stretching and cropping on resolutions wider than 1920 pixels
 Instead, it always displays the banner in full with sides filled in by the blurred original banner
 	`,
 	isDefault: false,
@@ -14,18 +14,22 @@ Instead, it always displays the banner in full with sides filled in by the blurr
 	},
 	code: function(){
 		let banner;
-		let adder = function(mutations, observer){
+		let adder = function(mutations,observer){
 			banner = document.querySelector(".media .banner");
 			if(!banner){
 				return
 			};
-			if(banner){
-				observer && observer.disconnect();
-				banner.classList.add("blur-filter");
-				let bannerFull = create("img","altBanner",null,banner);
-				bannerFull.height = "400";
-				bannerFull.src = banner.style.backgroundImage.replace("url(","").replace(")","").replace('"',"").replace('"',"")
-			}
+			observer && observer.disconnect();
+			let existingAlt = Array.from(document.querySelectorAll(".altBanner"));
+			if (existingAlt.length){
+				existingAlt.forEach(oldBanner => {
+				oldBanner.remove()
+				})
+			};
+			banner.classList.add("blur-filter");
+			let bannerFull = create("img","altBanner",null,banner);
+			bannerFull.height = "400";
+			bannerFull.src = banner.style.backgroundImage.replace("url(","").replace(")","").replace('"',"").replace('"',"")
 		};
 		adder();
 		let mutationConfig = {
@@ -42,7 +46,7 @@ Instead, it always displays the banner in full with sides filled in by the blurr
 		position: relative;
 		z-index: -2;
 	}
-	.blur-filter::after{
+	.blur-filter::after {
 		backdrop-filter: blur(10px);
 		content: "";
 		display: block;

--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -42,7 +42,7 @@ Instead, it always displays the banner in full with sides filled in by the blurr
 		position: relative;
 		z-index: -2;
 	}
-	.blur-filter::after {
+	.blur-filter::after{
 		backdrop-filter: blur(5px);
 		content: "";
 		display: block;

--- a/src/modules/altBanner.js
+++ b/src/modules/altBanner.js
@@ -46,7 +46,7 @@ Instead, it always displays the banner in full with sides filled in by the blurr
 		position: relative;
 		z-index: -2;
 	}
-	.blur-filter::after {
+	.blur-filter::after{
 		backdrop-filter: blur(10px);
 		content: "";
 		display: block;


### PR DESCRIPTION
New module to change the banner style. 

- Currently banners look bad on window/screen resolutions wider than 1920 pixels with extreme stretching and cropping.
- Only made it for media pages since it won't work as well on user profiles due to banner resolution/ratio not being enforced in uploads. (And most people not following the guideline). Though let me know if you think it should still be adapted for profiles.
- Made sure it is still compatible with banner downloads and banner shadows/no shadows.
- Discovered that AL also hard crops the banner & header height by 58 pixels (`.banner{margin-top: -58px;}`) for resolutions wider than 760px. I made this 0 too, though I'm not sure if it breaks anything (so far it doesn't seem like it).

Screenshots:
Option off
![image](https://user-images.githubusercontent.com/28376248/210550286-bc500236-8612-4b36-8f26-eeeb9a23536b.png)

Option on
![image](https://user-images.githubusercontent.com/28376248/210549449-f3c435f1-9bff-4255-83fe-aac0703eb7a0.png)

Option off
![image](https://user-images.githubusercontent.com/28376248/210550076-93bc3c88-fa30-413f-99f8-7a9b2d8efe84.png)

Option on
![image](https://user-images.githubusercontent.com/28376248/210555171-b6a21dd5-8584-42bb-8153-f99d895f0f5e.png)

Option off (Banner shadows on)
![image](https://user-images.githubusercontent.com/28376248/210551235-5db257ee-ae17-474f-9cc6-3a75e6461281.png)

Option on (Banner shadows on)
![image](https://user-images.githubusercontent.com/28376248/210555031-d0b67c2f-3bfc-4052-8ecb-f83b7411630b.png)