### PR TITLE
hideScores - add back observer.disconnect

### DIFF
--- a/src/modules/hideScores.js
+++ b/src/modules/hideScores.js
@@ -14,7 +14,7 @@ Does not hide scores set by other Automail options
 	},
 	code: function(){
 		if(/^\/(anime|manga)\/.*/.test(location.pathname)){
-			let scoreSpoiler = function(){
+			let scoreSpoiler = function(mutations,observer){
 				let sidebarNode = Array.from(document.querySelectorAll(".sidebar .data .data-set .type"));
 				if(!sidebarNode.length){
 					return
@@ -24,6 +24,7 @@ Does not hide scores set by other Automail options
 				let findMean = sidebarNode.find(element => element.innerText === "Mean Score");
 				findAvg && scoreNode.push(findAvg);
 				findMean && scoreNode.push(findMean);
+				findAvg && findMean && observer && observer.disconnect();
 				if(scoreNode.length){
 					scoreNode.forEach(score => {
 						if(!score.parentNode.children[1].hasAttribute("data-click")){
@@ -68,7 +69,7 @@ Does not hide scores set by other Automail options
 				subtree: true
 			};
 			let observer = new MutationObserver(scoreSpoiler);
-			observer.observe(document.body,mutationConfig);
+			observer.observe(document.body,mutationConfig)
 		};
 		if(/^\/home\/?$/.test(location.pathname) || /^\/forum\/thread\/.*/.test(location.pathname) || /^\/user\/.*/.test(location.pathname)){
 			let removeEmbedScore = function(){


### PR DESCRIPTION
Forgot to add `observer.disconnect()` back in. No longer need to observe if we have found and updated both Average and Mean scores.

**Side note:** Reason we need the observer is that sometimes the Mean score loads after the Average score, plus they don't have unique class names. However, some media may have a mean score but not an average score, so observers will never be disconnected for these (Potentially bad but at least there aren't many of them).
I'm also trying to avoid setTimeout/setInterval