### PR TITLE
Touchscreen/Small screen fixes - hohDisplayBox + tooltips

### DIFF
--- a/src/css/displayBox.css
+++ b/src/css/displayBox.css
@@ -2,7 +2,7 @@
 	position: fixed;
 	top: 80px;
 	left: 200px;
-	z-index: 999;
+	z-index: 9999;
 	padding: 20px;
 	background-color: rgb(var(--color-foreground));
 	border: solid 1px;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -2202,6 +2202,28 @@ a.external-link.Official.Site[href*=".jp"]::after{
 		line-height: 1;
 		z-index: 1;
 	}
+	.hohAdvancedDollar{
+		margin-left: 20px;
+	}
+	.hohAdvancedDollar:hover:before{
+		right: 5%;
+	}
+	.title .notes{
+		margin-left: 20px;
+	}
+	.repeat[label]:hover:after{
+		background: rgba(var(--color-overlay),.9);
+		color: rgb(var(--color-text-bright));
+		content: attr(label);
+		position: absolute;
+		top: 35%;
+		padding: 5px;
+		border-radius: 4px;
+		font-weight: normal;
+		font-size: 1.3rem;
+		white-space: pre;
+		z-index: 1000;
+	}
 }
 
 m4_include(css/footerLinks.css)

--- a/src/css/smallScreens.css
+++ b/src/css/smallScreens.css
@@ -142,6 +142,28 @@
 		padding-left: 0px;
 		padding-top: 15px;
 	}
+	.hohAdvancedDollar{
+		margin-left: 20px;
+	}
+	.hohAdvancedDollar:hover:before{
+		right: 5%;
+	}
+	.title .notes{
+		margin-left: 20px;
+	}
+	.repeat[label]:hover:after{
+		background: rgba(var(--color-overlay),.9);
+		color: rgb(var(--color-text-bright));
+		content: attr(label);
+		position: absolute;
+		top: 35%;
+		padding: 5px;
+		border-radius: 4px;
+		font-weight: normal;
+		font-size: 1.3rem;
+		white-space: pre;
+		z-index: 1000;
+	}
 }
 @media(max-width: 500px){
 	.footer [href="https://anilist.co"],

--- a/src/css/smallScreens.css
+++ b/src/css/smallScreens.css
@@ -128,6 +128,20 @@
 	.media p.description:empty{
 		display: none;
 	}
+	.hohDisplayBox{
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		min-width: 50px!important;
+		width: 100%;
+		min-height: 100px!important;
+		height: 80%;
+	}
+	.hohDisplayBox .scrollableContent{
+		padding: 10px;
+		padding-left: 0px;
+		padding-top: 15px;
+	}
 }
 @media(max-width: 500px){
 	.footer [href="https://anilist.co"],
@@ -142,5 +156,19 @@
 	}
 	.hohColourPicker{
 		display: none;
+	}
+}
+@media(max-height: 500px){
+	.hohDisplayBox{
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		min-height: 100px!important;
+		height: 90%;
+	}
+	.hohDisplayBox .scrollableContent{
+		padding: 10px;
+		padding-left: 0px;
+		padding-top: 15px;
 	}
 }


### PR DESCRIPTION
Some more mobile fixes

hohDisplayBox gets cut off at the side on small screens due to fixed positioning, 

![image](https://user-images.githubusercontent.com/28376248/212487949-7eb59878-f1ad-4652-bbf8-92da84b72a9a.png)  Fixed: ![image](https://user-images.githubusercontent.com/28376248/212489718-b2186c15-7c16-4389-9440-20369d30beac.png)

Updated to center the box for both small widths and heights. Also fixed the box getting covered by pop up cover images.
Side note: Dragging/re-sizing the box does not currently work on touchscreens. Super long notes are still sometimes cut off at bottom on normal resolutions.

Fixed tooltips not working in user lists (`.repeat` and `hohAdvancedDollar`). Notes can use the display box.
Fix needs to be applied to both touchscreens and small screens as both can occur separately.
Note: Only works in Semi-compact list view. Compact view is just natively broken with the edit button in the way, not sure how to fix that