### PR TITLE
Fixed title/status overflow in verticalNav

### DIFF
--- a/src/css/verticalNav.css
+++ b/src/css/verticalNav.css
@@ -512,6 +512,7 @@ div#nav.nav .link.router-link-exact-active.router-link-active,
 }
 .status{
 	display: inline-block!important;
+	margin-right: 75px;
 }
 .avatar{
 	display: block!important;


### PR DESCRIPTION
Fixed verticalNav titles/status at certain lengths overflowing into the time on feeds (both single column and double column)

![image](https://user-images.githubusercontent.com/28376248/212674684-ceb61665-4651-4ccf-a722-2b3e5e90d772.png)

Also I think it would be a good idea to have another verticalNav option without all the extra styling to the body (but maybe it's just me)