### PR TITLE
Copy manifest to addon build

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -31,7 +31,7 @@ build:
 build/firefox_addon.zip: build/automail.js ../icons manifest.json
 	$(info )
 	$(info Creating Firefox addon)
-	cd build && cp -r ../../icons/ icons/ && zip -r firefox_addon.zip automail.js icons/ ../manifest.json && rm -fr icons
+	cd build && cp -r ../../icons/ icons/ && cp ../manifest.json . && zip -r firefox_addon.zip automail.js icons/ manifest.json && rm -fr icons manifest.json
 
 post-build:
 	$(info )


### PR DESCRIPTION
I had noticed whenever running the build script the addon zip was always missing the manifest file. I don't know if it's an issue with the zip utility or a platform issue, so I fixed it by explicitly copying the manifest into the directory before creating the archive.