### PR TITLE
Add Canadian English

### DIFF
--- a/src/data/languages/English_CA.json
+++ b/src/data/languages/English_CA.json
@@ -1,0 +1,19 @@
+{
+	"info": {
+		"language": "English (CA)",
+		"language_english": "English (CA)",
+		"variation_of": "English",
+		"locale": "en-CA",
+		"fallback": ["English"],
+		"maintainer": "Zarin",
+		"maintainer_link": "https://github.com/kazzarin",
+		"discussion_link": "",
+		"notes": "There's in general no need to translate all the keys, since the default fallback is English."
+	},
+	"keys": {
+"$MAL_serialization": "Serialization",
+"$compare_normalizeRatings": "Normalize ratings:",
+"$setting_MALserial": "Add MAL serialization info to manga",
+"$forumCategory_14": "List Customization"
+	}
+}

--- a/src/data/legacyModuleDescriptions.json
+++ b/src/data/legacyModuleDescriptions.json
@@ -270,6 +270,6 @@
 	"type": "select",
 	"importance": 100,
 	"categories": ["Script"],
-	"values": ["English","Italiano","Français","Português","Español","Norsk","日本語","Türkçe","Deutsch","Åarjelsaemie","Svenska","English (US)","English (short)","$raw_keys"]
+	"values": ["English","Italiano","Français","Português","Español","Norsk","日本語","Türkçe","Deutsch","Åarjelsaemie","Svenska","English (US)","English (CA)","English (short)","$raw_keys"]
 }
 ]

--- a/src/localisation.js
+++ b/src/localisation.js
@@ -11,6 +11,7 @@ const languageFiles = {//key: language name in language ("日本語"), filename:
 	"Norsk": m4_include(data/languages/Norwegian.json),
 	"Svenska": m4_include(data/languages/Swedish.json),
 	"English (US)": m4_include(data/languages/English_US.json),
+	"English (CA)": m4_include(data/languages/English_CA.json),
 	"English (short)": m4_include(data/languages/English_short.json),
 	"Español": m4_include(data/languages/Spanish.json),
 	"$raw_keys": m4_include(data/languages/raw_keys.json)

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -194,8 +194,8 @@ function nativeTimeElement(timestamp){//time in seconds
 	let dateObj = new Date(timestamp*1000);
 	let elem = create("time","hohTimeGeneric");
 	elem.setAttribute("datetime",dateObj);
-	let locale = languageFiles[useScripts.partialLocalisationLanguage].info.locale || "en-UK";
-	elem.title = dateObj.toLocaleDateString(locale,{weekday: undefined, year: "numeric", month: "numeric", day: "numeric"}) + ", " + dateObj.toLocaleTimeString(locale);
+	let locale = languageFiles[useScripts.partialLocalisationLanguage].info.locale || undefined;
+	elem.title = dateObj.toLocaleString(locale);
 	let calculateTime = function(){
 		let now = new Date();
 		let diff = Math.round(now.valueOf()/1000) - Math.round(dateObj.valueOf()/1000);


### PR DESCRIPTION
- Adds a translation stub for Canadian english (only a couple differences with UK english )
- Changed the time element to fallback to the browser locale instead of forcing the "en-UK" locale