### PR TITLE
Fix Twitter embed check

### DIFF
--- a/src/modules/tweets.js
+++ b/src/modules/tweets.js
@@ -2,8 +2,7 @@ exportModule({
 	id: "tweets",
 	description: "$setting_tweets",
 	extendedDescription: `
-This works by running Twitter's official embedding script. But since loading external code is not allowed for Firefox addons, this setting will only work in userscript mode.
-Be advised that Twitter embeds display NSFW content no differently than other content.
+This works by running Twitter's official embedding script. Be advised that Twitter embeds display NSFW content no differently than other content.
 	`,
 	isDefault: false,
 	categories: ["Feeds"],
@@ -11,42 +10,41 @@ Be advised that Twitter embeds display NSFW content no differently than other co
 	boneless_disabled: true
 })
 
+const isPublishedMozillaAddon = false;
 let tweetLoop;
-if(useScripts.tweets){
-	if(typeof browser === "undefined" && typeof chrome === "undefined"){//skip running script regardless of setting if addon api is detected
-		tweetLoop = setInterval(function(){
-			document.querySelectorAll(
-				`.markdown a[href^="https://twitter.com/"][href*="/status/"]`
-			).forEach(tweet => {
-				if(tweet.classList.contains("hohEmbedded")){
-					return
-				}
-				let tweetMatch = tweet.href.match(/^https:\/\/twitter\.com\/(.+?)\/status\/\d+/)
-				if(!tweetMatch || tweet.href !== tweet.innerText){
-					return
-				}
-				tweet.classList.add("hohEmbedded");
-				let tweetBlockQuote = create("blockquote",false,false,tweet);
-				tweetBlockQuote.classList.add("twitter-tweet");
-				if(document.body.classList.contains("site-theme-dark")){
-					tweetBlockQuote.setAttribute("data-theme","dark")
-				}
-				let tweetBlockQuoteInner = create("p",false,false,tweetBlockQuote);
-				tweetBlockQuoteInner.setAttribute("lang","en");
-				tweetBlockQuoteInner.setAttribute("dir","ltr");
-				let tweetBlockQuoteInnerInner = create("a","hohEmbedded","Loading tweet by " + tweetMatch[1] + "...",tweetBlockQuoteInner)
-					.href = tweet.href;
-				if(document.getElementById("hohTwitterEmbed") && window.twttr){
-					window.twttr.widgets.load(tweet)
-				}
-				else{
-					let script = document.createElement("script");
-					script.setAttribute("src","https://platform.twitter.com/widgets.js");
-					script.setAttribute("async","");
-					script.id = "hohTwitterEmbed";
-					document.head.appendChild(script)
-				}
-			})
-		},400);
-	}
+if(useScripts.tweets && !isPublishedMozillaAddon){
+	tweetLoop = setInterval(function(){
+		document.querySelectorAll(
+			`.markdown a[href^="https://twitter.com/"][href*="/status/"]`
+		).forEach(tweet => {
+			if(tweet.classList.contains("hohEmbedded")){
+				return
+			}
+			let tweetMatch = tweet.href.match(/^https:\/\/twitter\.com\/(.+?)\/status\/\d+/)
+			if(!tweetMatch || tweet.href !== tweet.innerText){
+				return
+			}
+			tweet.classList.add("hohEmbedded");
+			let tweetBlockQuote = create("blockquote",false,false,tweet);
+			tweetBlockQuote.classList.add("twitter-tweet");
+			if(document.body.classList.contains("site-theme-dark")){
+				tweetBlockQuote.setAttribute("data-theme","dark")
+			}
+			let tweetBlockQuoteInner = create("p",false,false,tweetBlockQuote);
+			tweetBlockQuoteInner.setAttribute("lang","en");
+			tweetBlockQuoteInner.setAttribute("dir","ltr");
+			let tweetBlockQuoteInnerInner = create("a","hohEmbedded","Loading tweet by " + tweetMatch[1] + "...",tweetBlockQuoteInner)
+				.href = tweet.href;
+			if(document.getElementById("hohTwitterEmbed") && window.twttr){
+				window.twttr.widgets.load(tweet)
+			}
+			else{
+				let script = document.createElement("script");
+				script.setAttribute("src","https://platform.twitter.com/widgets.js");
+				script.setAttribute("async","");
+				script.id = "hohTwitterEmbed";
+				document.head.appendChild(script)
+			}
+		})
+	},400);
 }

--- a/src/modules/tweets.js
+++ b/src/modules/tweets.js
@@ -2,8 +2,8 @@ exportModule({
 	id: "tweets",
 	description: "$setting_tweets",
 	extendedDescription: `
-This works by runnig Twitter's official embedding script. But since loading external code is not allowed for Firefox addons, this setting will only work in userscript mode.
-Be adviced that Twitter embedding displays NSFW content no differently than other content.
+This works by running Twitter's official embedding script. But since loading external code is not allowed for Firefox addons, this setting will only work in userscript mode.
+Be advised that Twitter embeds display NSFW content no differently than other content.
 	`,
 	isDefault: false,
 	categories: ["Feeds"],
@@ -11,35 +11,31 @@ Be adviced that Twitter embedding displays NSFW content no differently than othe
 	boneless_disabled: true
 })
 
-let tweetLoop = setInterval(function(){
-	if(useScripts.tweets){
-		document.querySelectorAll(
-			`.markdown a[href^="https://twitter.com/"][href*="/status/"]`
-		).forEach(tweet => {
-			if(tweet.classList.contains("hohEmbedded")){
-				return
-			}
-			let tweetMatch = tweet.href.match(/^https:\/\/twitter\.com\/(.+?)\/status\/\d+/)
-			if(!tweetMatch || tweet.href !== tweet.innerText){
-				return
-			}
-			tweet.classList.add("hohEmbedded");
-			let tweetBlockQuote = create("blockquote",false,false,tweet);
-			tweetBlockQuote.classList.add("twitter-tweet");
-			if(document.body.classList.contains("site-theme-dark")){
-				tweetBlockQuote.setAttribute("data-theme","dark")
-			}
-			let tweetBlockQuoteInner = create("p",false,false,tweetBlockQuote);
-			tweetBlockQuoteInner.setAttribute("lang","en");
-			tweetBlockQuoteInner.setAttribute("dir","ltr");
-			let tweetBlockQuoteInnerInner = create("a","hohEmbedded","Loading tweet by " + tweetMatch[1] + "...",tweetBlockQuoteInner)
-				.href = tweet.href;
-			if(window.GM_xmlhttpRequest){
-				/*
-					Only fetch external script if running in userscript mode (window.GM_xmlhttpRequest is only available inside a userscript manager)
-					This is not allowed for Firefox addons, even if this setting is disabled by default.
-					Hence this check
-				*/
+let tweetLoop;
+if(useScripts.tweets){
+	if(typeof browser === "undefined" && typeof chrome === "undefined"){//skip running script regardless of setting if addon api is detected
+		tweetLoop = setInterval(function(){
+			document.querySelectorAll(
+				`.markdown a[href^="https://twitter.com/"][href*="/status/"]`
+			).forEach(tweet => {
+				if(tweet.classList.contains("hohEmbedded")){
+					return
+				}
+				let tweetMatch = tweet.href.match(/^https:\/\/twitter\.com\/(.+?)\/status\/\d+/)
+				if(!tweetMatch || tweet.href !== tweet.innerText){
+					return
+				}
+				tweet.classList.add("hohEmbedded");
+				let tweetBlockQuote = create("blockquote",false,false,tweet);
+				tweetBlockQuote.classList.add("twitter-tweet");
+				if(document.body.classList.contains("site-theme-dark")){
+					tweetBlockQuote.setAttribute("data-theme","dark")
+				}
+				let tweetBlockQuoteInner = create("p",false,false,tweetBlockQuote);
+				tweetBlockQuoteInner.setAttribute("lang","en");
+				tweetBlockQuoteInner.setAttribute("dir","ltr");
+				let tweetBlockQuoteInnerInner = create("a","hohEmbedded","Loading tweet by " + tweetMatch[1] + "...",tweetBlockQuoteInner)
+					.href = tweet.href;
 				if(document.getElementById("hohTwitterEmbed") && window.twttr){
 					window.twttr.widgets.load(tweet)
 				}
@@ -50,7 +46,7 @@ let tweetLoop = setInterval(function(){
 					script.id = "hohTwitterEmbed";
 					document.head.appendChild(script)
 				}
-			}
-		})
+			})
+		},400);
 	}
-},400);
+}


### PR DESCRIPTION
Fixes #250 
After testing with FireMonkey, I found the check for `window.GM_xmlhttpRequest` was failing leaving the loading placeholder as described in the above issue. Since the check isn't that reliable for detecting if the script is running as an addon, I changed it to check for `browser`/`chrome` instead, which are extension-only globals.

That aside, iirc the restriction was a FF AMO thing, and since the addon is no longer updated there the check is probably not needed.