### PR TITLE
imageFreeEditor: fix styling for long titles

### DIFF
--- a/src/modules/imageFreeEditor.js
+++ b/src/modules/imageFreeEditor.js
@@ -11,13 +11,32 @@ exportModule({
 }
 .list-editor-wrap .header{
 	background-image: none!important;
-	height: 0px;
+	height: auto;
+	box-shadow: none;
+	background: rgb(var(--color-foreground));
+}
+.list-editor-wrap .header::after{
+	background: none;
 }
 .list-editor-wrap .header .content{
-	padding-top: 2px;
-	padding-left: 35px;
-	padding-right: 120px;
-	height: 60px;
+	align-items: center;
+}
+.list-editor-wrap .header .title{
+	padding: 0;
+}
+.list-editor-wrap .header .favourite{
+	margin-bottom: 0;
+}
+.list-editor-wrap .header .save-btn{
+	margin-bottom: 0;
+}
+.list-editor-wrap .list-editor .body{
+	padding-top: 20px;
+}
+@media (max-width: 760px){
+	.list-editor-wrap .header .content{
+		padding-top: 60px;
+	}
 }
 	`
 })


### PR DESCRIPTION
Also touched up the styling to look more even with the rest of the modal.

Example: https://anilist.co/manga/110801/Honzuki-no-Gekokujou-Shisho-ni-Naru-Tame-ni-wa-Shudan-wo-Erandeiraremasen-Dai-3bu--Ryoushu-no-Youjo/

Before|After
--|--
![](https://0x0.st/oCCA.png)|![](https://0x0.st/oCCc.png)

Mobile (pseudo)

Before|After
--|--
![](https://0x0.st/oCCm.png)|![](https://0x0.st/oCCT.png)
