### PR TITLE
Fix FireMonkey compatibility

### DIFF
--- a/src/modules/addMALscore.js
+++ b/src/modules/addMALscore.js
@@ -122,6 +122,12 @@ async function addMALscore(type,id){
 					onload: function(response){handler(response)}
 				})
 			}
+			else{
+				let oReq = new XMLHttpRequest();
+				oReq.addEventListener("load",function(){handler(this)});
+				oReq.open("GET","https://myanimelist.net/" + type + "/" + data.data.Media.idMal + "/placeholder/userrecs");
+				oReq.send()
+			}
 		}
 	}
 	else{

--- a/src/modules/addMALscore.js
+++ b/src/modules/addMALscore.js
@@ -114,19 +114,13 @@ async function addMALscore(type,id){
 					adder()
 				}
 			}
-			if(window.GM_xmlhttpRequest){
+			if(GM_xmlhttpRequest){
 				GM_xmlhttpRequest({
 					method: "GET",
 					anonymous: true,
 					url: "https://myanimelist.net/" + type + "/" + data.data.Media.idMal + "/placeholder/userrecs",
 					onload: function(response){handler(response)}
 				})
-			}
-			else{
-				let oReq = new XMLHttpRequest();
-				oReq.addEventListener("load",function(){handler(this)});
-				oReq.open("GET","https://myanimelist.net/" + type + "/" + data.data.Media.idMal + "/placeholder/userrecs");
-				oReq.send()
 			}
 		}
 	}

--- a/src/modules/addMALscore.js
+++ b/src/modules/addMALscore.js
@@ -114,7 +114,7 @@ async function addMALscore(type,id){
 					adder()
 				}
 			}
-			if(GM_xmlhttpRequest){
+			if(typeof GM_xmlhttpRequest === "function"){
 				GM_xmlhttpRequest({
 					method: "GET",
 					anonymous: true,

--- a/src/modules/addMoreStats.js
+++ b/src/modules/addMoreStats.js
@@ -1767,10 +1767,17 @@ function addMoreStats(){
 	}//end boneless check
 			return
 		};
-		if(user === whoAmI && reliablePersistentStorage){
-			cache.getList("ANIME",function(data){
-				personalStatsCallback(data)
-			})
+		if(user === whoAmI){
+			const animeData = await anilistAPI(cache.listQuery.ANIME, {
+				variables: {name: user},
+				cacheKey: "ListCacheANIME" + user,
+				duration: 60*60*1000,
+				auth: true
+			});
+			if(animeData.errors){
+				return
+			}
+			personalStatsCallback(animeData)
 		}
 		else{
 			const animeData = await anilistAPI(queryMediaListAnime, {
@@ -2437,10 +2444,17 @@ function addMoreStats(){
 			};waiter();
 			return
 		};
-		if(user === whoAmI && reliablePersistentStorage){
-			cache.getList("MANGA",data => {
-				personalStatsMangaCallback(data)
-			})
+		if(user === whoAmI){
+			const mangaData = await anilistAPI(cache.listQuery.MANGA, {
+				variables: {name: user},
+				cacheKey: "ListCacheMANGA" + user,
+				duration: 60*60*1000,
+				auth: true
+			});
+			if(mangaData.errors){
+				return
+			}
+			personalStatsMangaCallback(mangaData)
 		}
 		else{
 			const mangaData = await anilistAPI(queryMediaListManga, {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -740,12 +740,16 @@ function returnList(list,skipProcessing){
 		return null
 	}
 	let retl = [];
-	list.data.MediaListCollection.lists.forEach(mediaList => {
-		mediaList.entries.forEach(entry => {
-			if(!skipProcessing){
-				entry.isCustomList = mediaList.isCustomList;
+	if(skipProcessing){
+		retl = list.data.MediaListCollection.lists.map(list => list.entries).flat();
+	}
+	else {
+		retl = list.data.MediaListCollection.lists.map(list => {
+			return list.entries.map(_entry => {
+				const entry = structuredClone(_entry);
+				entry.isCustomList = list.isCustomList;
 				if(entry.isCustomList){
-					entry.listLocations = [mediaList.name]
+					entry.listLocations = [list.name]
 				}
 				else{
 					entry.listLocations = []
@@ -773,10 +777,10 @@ function returnList(list,skipProcessing){
 				if(entry.status === "REPEATING" && entry.repeat === 0){
 					entry.repeat = 1
 				}
-			}
-			retl.push(entry);
-		})
-	})
+				return entry;
+			})
+		}).flat();
+	}
 	return removeGroupedDuplicates(
 		retl,
 		e => e.mediaId,

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -739,7 +739,7 @@ function returnList(_list,skipProcessing){
 	if(!_list){
 		return null
 	}
-	const list = structuredClone(_list);
+	const list = window.structuredClone ? structuredClone(_list) : _list;
 	let retl = [];
 	if(skipProcessing){
 		retl = list.data.MediaListCollection.lists.map(list => list.entries).flat();

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -735,18 +735,18 @@ let makeHtml = function(markdown){
 	return converter.makeHtml(preProcessed.join(""))
 }
 
-function returnList(list,skipProcessing){
-	if(!list){
+function returnList(_list,skipProcessing){
+	if(!_list){
 		return null
 	}
+	const list = structuredClone(_list);
 	let retl = [];
 	if(skipProcessing){
 		retl = list.data.MediaListCollection.lists.map(list => list.entries).flat();
 	}
 	else {
 		retl = list.data.MediaListCollection.lists.map(list => {
-			return list.entries.map(_entry => {
-				const entry = structuredClone(_entry);
+			return list.entries.map(entry => {
 				entry.isCustomList = list.isCustomList;
 				if(entry.isCustomList){
 					entry.listLocations = [list.name]


### PR DESCRIPTION
Fixes #251
- used [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) to resolve Xray error
  - a shallow clone like ```const entry = {..._entry}``` didn't work because it would still error on the `entry.media` object
  - todo: look for a polyfill since it's a newer feature
- no longer depend on cache.js in stats module (mostly)
  - apiv2 can handle caching lists in a similar way
  - (this didn't have any effect on the main issue, though i changed it to rule it out anyways)
- fixed another GM xhr check for mal recs
  - removed the xhr backup as that will fail anyways because of cors
  - (might look into using jikan for this instead)