### PR TITLE
Rework browseFilters

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -203,16 +203,6 @@ function handleScripts(url,oldUrl){
 			enhanceStaffBrowse()
 		}
 	}
-	else if(url.match(/^https:\/\/anilist\.co\/search\/anime/)){
-		if(useScripts.browseFilters){
-			addBrowseFilters("anime")
-		}
-	}
-	else if(url.match(/^https:\/\/anilist\.co\/search\/manga/)){
-		if(useScripts.browseFilters){
-			addBrowseFilters("manga")
-		}
-	}
 	let mangaAnimeMatch = url.match(/^https:\/\/anilist\.co\/(anime|manga)\/(\d+)\/?([^/]*)?\/?(.*)?/);
 	if(mangaAnimeMatch){
 		let adder = function(){

--- a/src/data/legacyModuleDescriptions.json
+++ b/src/data/legacyModuleDescriptions.json
@@ -47,9 +47,6 @@
 },{"id": "activityTimeline",
 	"description": "$activityTimeline_description",
 	"categories": ["Media","Navigation"]
-},{"id": "browseFilters",
-	"description": "$browseFilters_description",
-	"categories": ["Browse"]
 },{"id": "completedScore",
 	"description": "$completedScore_description",
 	"categories": ["Feeds"]

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -23,28 +23,27 @@ function addBrowseFilters(type){
 		}
 		let alreadyAdded = document.querySelectorAll(".hohSorts");
 		alreadyAdded.forEach(aready => aready.remove());
-		const linkHandler = function(elem, query){
-			const pageQuery = Object.fromEntries(new URLSearchParams(location.search));
-			if(/\/top-manhwa$/.test(location.pathname)){
-				pageQuery["country of origin"] = "KR";
+		const linkHandler = function(elem, sort){
+			elem.onclick = () => {
+				sorts.__vue__.setSort(sort);
+				sorts.__vue__.close();
 			}
-			cheapReload(elem, {...{name: "Search", params: {type}}, ...{query: pageQuery}, ...query})
 		};
 		if(type === "anime"){
 			let episodeSort = create("div",["option","hohSorts"],"Episodes ↓",dropdown);
 			let episodeSortb = create("div",["option","hohSorts"],"Episodes ↑",dropdown);
-			linkHandler(episodeSort, {query: {sort: "EPISODES_DESC"}})
-			linkHandler(episodeSortb, {query: {sort: "EPISODES"}})
+			linkHandler(episodeSort, "EPISODES_DESC")
+			linkHandler(episodeSortb, "EPISODES")
 		}
 		else if(type === "manga"){
 			let chapterSort = create("div",["option","hohSorts"],"Chapters ↓",dropdown);
 			let chapterSortb = create("div",["option","hohSorts"],"Chapters ↑",dropdown);
 			let volumeSort = create("div",["option","hohSorts"],"Volumes ↓",dropdown);
 			let volumeSortb = create("div",["option","hohSorts"],"Volumes ↑",dropdown);
-			linkHandler(chapterSort, {query: {sort: "CHAPTERS_DESC"}})
-			linkHandler(chapterSortb, {query: {sort: "CHAPTERS"}})
-			linkHandler(volumeSort, {query: {sort: "VOLUMES_DESC"}})
-			linkHandler(volumeSortb, {query: {sort: "VOLUMES"}})
+			linkHandler(chapterSort, "CHAPTERS_DESC")
+			linkHandler(chapterSortb, "CHAPTERS")
+			linkHandler(volumeSort, "VOLUMES_DESC")
+			linkHandler(volumeSortb, "VOLUMES")
 		}
 	}
 	sorts.addEventListener("click", applySorts)

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -23,48 +23,28 @@ function addBrowseFilters(type){
 		}
 		let alreadyAdded = document.querySelectorAll(".hohSorts");
 		alreadyAdded.forEach(aready => aready.remove());
-		let URLredirect = function(property,value){
-			let url = new URLSearchParams(location.search);
-			url.set(property,value);
-			if(location.pathname.match(/\/top-manhwa$/)){
-				url.set("country of origin","KR")
+		const linkHandler = function(elem, query){
+			const pageQuery = Object.fromEntries(new URLSearchParams(location.search));
+			if(/\/top-manhwa$/.test(location.pathname)){
+				pageQuery["country of origin"] = "KR";
 			}
-			window.location.href = location.protocol
-			+ "//"
-			+ location.host
-			+ location.pathname.replace(
-				/\/(popular|top-100|next-season|this-season|trending|top-manhwa|new)$/,
-				""
-			)
-			+ "?" + url.toString()
+			cheapReload(elem, {...{name: "Search", params: {type}}, ...{query: pageQuery}, ...query})
 		};
 		if(type === "anime"){
 			let episodeSort = create("div",["option","hohSorts"],"Episodes ↓",dropdown);
 			let episodeSortb = create("div",["option","hohSorts"],"Episodes ↑",dropdown);
-			episodeSort.onclick = function(){
-				URLredirect("sort","EPISODES_DESC")
-			};
-			episodeSortb.onclick = function(){
-				URLredirect("sort","EPISODES")
-			}
+			linkHandler(episodeSort, {query: {sort: "EPISODES_DESC"}})
+			linkHandler(episodeSortb, {query: {sort: "EPISODES"}})
 		}
 		else if(type === "manga"){
 			let chapterSort = create("div",["option","hohSorts"],"Chapters ↓",dropdown);
 			let chapterSortb = create("div",["option","hohSorts"],"Chapters ↑",dropdown);
 			let volumeSort = create("div",["option","hohSorts"],"Volumes ↓",dropdown);
 			let volumeSortb = create("div",["option","hohSorts"],"Volumes ↑",dropdown);
-			chapterSort.onclick = function(){
-				URLredirect("sort","CHAPTERS_DESC")
-			};
-			chapterSortb.onclick = function(){
-				URLredirect("sort","CHAPTERS")
-			};
-			volumeSort.onclick = function(){
-				URLredirect("sort","VOLUMES_DESC")
-			};
-			volumeSortb.onclick = function(){
-				URLredirect("sort","VOLUMES")
-			}
+			linkHandler(chapterSort, {query: {sort: "CHAPTERS_DESC"}})
+			linkHandler(chapterSortb, {query: {sort: "CHAPTERS"}})
+			linkHandler(volumeSort, {query: {sort: "VOLUMES_DESC"}})
+			linkHandler(volumeSortb, {query: {sort: "VOLUMES"}})
 		}
 	}
 	sorts.addEventListener("click", applySorts)

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -67,5 +67,5 @@ function addBrowseFilters(type){
 			}
 		}
 	}
-	sorts.onclick = applySorts();
+	sorts.addEventListener("click", applySorts)
 }

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -33,7 +33,7 @@ function addBrowseFilters(type){
 			+ "//"
 			+ location.host
 			+ location.pathname.replace(
-				/\/(popular|top-100|next-season|this-season|trending|top-manhwa)$/,
+				/\/(popular|top-100|next-season|this-season|trending|top-manhwa|new)$/,
 				""
 			)
 			+ "?" + url.toString()

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -11,14 +11,22 @@ function addBrowseFilters(type){
 		}
 		sorts.classList.add("hohAlready")
 	}
-	const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑"};
+	const customSorts = {
+		TITLE_ROMAJI: "Title ↑", TITLE_ROMAJI_DESC: "Title ↓",
+		POPULARITY_DESC: "Popularity ↓", POPULARITY: "Popularity ↑",
+		SCORE_DESC: "Average Score ↓", SCORE: "Average Score ↑",
+		FAVOURITES_DESC: "Favorites ↓", FAVOURITES: "Favorites ↑",
+		ID_DESC: "Date Added ↓", ID: "Date Added ↑",
+		START_DATE_DESC: "Release Date ↓", START_DATE: "Release Date ↑"
+	};
+	const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑", DURATION_DESC: "Duration ↓", DURATION: "Duration ↑"};
 	const customManga = {CHAPTERS_DESC: "Chapters ↓", CHAPTERS: "Chapters ↑", VOLUMES_DESC: "Volumes ↓", VOLUMES: "Volumes ↑"};
 	if(type === "anime"){
 		Object.keys(customManga).forEach(key => delete sorts.__vue__.sortOptions[key])
-		Object.assign(sorts.__vue__.sortOptions, customAnime)
+		Object.assign(sorts.__vue__.sortOptions, customSorts, customAnime)
 	}
 	else if(type === "manga"){
 		Object.keys(customAnime).forEach(key => delete sorts.__vue__.sortOptions[key])
-		Object.assign(sorts.__vue__.sortOptions, customManga)
+		Object.assign(sorts.__vue__.sortOptions, customSorts, customManga)
 	}
 }

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -12,21 +12,26 @@ function addBrowseFilters(type){
 		sorts.classList.add("hohAlready")
 	}
 	const customSorts = {
-		TITLE_ROMAJI: "Title ↑", TITLE_ROMAJI_DESC: "Title ↓",
-		POPULARITY_DESC: "Popularity ↓", POPULARITY: "Popularity ↑",
-		SCORE_DESC: "Average Score ↓", SCORE: "Average Score ↑",
-		FAVOURITES_DESC: "Favorites ↓", FAVOURITES: "Favorites ↑",
-		ID_DESC: "Date Added ↓", ID: "Date Added ↑",
-		START_DATE_DESC: "Release Date ↓", START_DATE: "Release Date ↑"
+		TITLE_ROMAJI: "Title ↑",
+		TITLE_ROMAJI_DESC: "Title ↓",
+		POPULARITY_DESC: "Popularity ↓",
+		POPULARITY: "Popularity ↑",
+		SCORE_DESC: "Average Score ↓",
+		SCORE: "Average Score ↑",
+		TRENDING_DESC: "Trending",
+		FAVOURITES_DESC: "Favorites",
+		ID_DESC: "Date Added",
+		START_DATE_DESC: "Release Date ↓",
+		START_DATE: "Release Date ↑"
 	};
 	const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑", DURATION_DESC: "Duration ↓", DURATION: "Duration ↑"};
 	const customManga = {CHAPTERS_DESC: "Chapters ↓", CHAPTERS: "Chapters ↑", VOLUMES_DESC: "Volumes ↓", VOLUMES: "Volumes ↑"};
 	if(type === "anime"){
-		Object.keys(customManga).forEach(key => delete sorts.__vue__.sortOptions[key])
+		Object.keys(sorts.__vue__.sortOptions).forEach(key => delete sorts.__vue__.sortOptions[key])
 		Object.assign(sorts.__vue__.sortOptions, customSorts, customAnime)
 	}
 	else if(type === "manga"){
-		Object.keys(customAnime).forEach(key => delete sorts.__vue__.sortOptions[key])
+		Object.keys(sorts.__vue__.sortOptions).forEach(key => delete sorts.__vue__.sortOptions[key])
 		Object.assign(sorts.__vue__.sortOptions, customSorts, customManga)
 	}
 }

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -1,37 +1,33 @@
-function addBrowseFilters(type){
-	if(! /^\/search/.test(location.pathname)){
-		return
-	}
-	let sorts = document.querySelector(".hohAlready");
-	if(!sorts){
-		sorts = document.querySelector(".sort-wrap.sort-select");
-		if(!sorts){
-			setTimeout(function(){addBrowseFilters(type)},200);
-			return
+exportModule({
+	id: "browseFilters",
+	description: "$browseFilters_description",
+	isDefault: true,
+	categories: ["Browse"],
+	urlMatch: function(url){
+		return /^https:\/\/anilist\.co\/search\/(anime|manga)/.test(url);
+	},
+	code: function(){
+		const customSorts = {
+			TITLE_ROMAJI: "Title ↑",
+			TITLE_ROMAJI_DESC: "Title ↓",
+			POPULARITY_DESC: "Popularity ↓",
+			POPULARITY: "Popularity ↑",
+			SCORE_DESC: "Average Score ↓",
+			SCORE: "Average Score ↑",
+			TRENDING_DESC: "Trending",
+			FAVOURITES_DESC: "Favorites",
+			ID_DESC: "Date Added",
+			START_DATE_DESC: "Release Date ↓",
+			START_DATE: "Release Date ↑"
+		};
+		const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑", DURATION_DESC: "Duration ↓", DURATION: "Duration ↑"};
+		const customManga = {CHAPTERS_DESC: "Chapters ↓", CHAPTERS: "Chapters ↑", VOLUMES_DESC: "Volumes ↓", VOLUMES: "Volumes ↑"};
+		const sorts = document.querySelector(".sort-wrap.sort-select");
+		function addSorts(){
+			const type = location.pathname.match(/^\/search\/(anime|manga)/)[1];
+			Object.keys(sorts.__vue__.sortOptions).forEach(key => delete sorts.__vue__.sortOptions[key])
+			Object.assign(sorts.__vue__.sortOptions, customSorts, type === "anime" ? customAnime : customManga)
 		}
-		sorts.classList.add("hohAlready")
+		setTimeout(addSorts,200);
 	}
-	const customSorts = {
-		TITLE_ROMAJI: "Title ↑",
-		TITLE_ROMAJI_DESC: "Title ↓",
-		POPULARITY_DESC: "Popularity ↓",
-		POPULARITY: "Popularity ↑",
-		SCORE_DESC: "Average Score ↓",
-		SCORE: "Average Score ↑",
-		TRENDING_DESC: "Trending",
-		FAVOURITES_DESC: "Favorites",
-		ID_DESC: "Date Added",
-		START_DATE_DESC: "Release Date ↓",
-		START_DATE: "Release Date ↑"
-	};
-	const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑", DURATION_DESC: "Duration ↓", DURATION: "Duration ↑"};
-	const customManga = {CHAPTERS_DESC: "Chapters ↓", CHAPTERS: "Chapters ↑", VOLUMES_DESC: "Volumes ↓", VOLUMES: "Volumes ↑"};
-	if(type === "anime"){
-		Object.keys(sorts.__vue__.sortOptions).forEach(key => delete sorts.__vue__.sortOptions[key])
-		Object.assign(sorts.__vue__.sortOptions, customSorts, customAnime)
-	}
-	else if(type === "manga"){
-		Object.keys(sorts.__vue__.sortOptions).forEach(key => delete sorts.__vue__.sortOptions[key])
-		Object.assign(sorts.__vue__.sortOptions, customSorts, customManga)
-	}
-}
+})

--- a/src/modules/addBrowseFilters.js
+++ b/src/modules/addBrowseFilters.js
@@ -11,40 +11,14 @@ function addBrowseFilters(type){
 		}
 		sorts.classList.add("hohAlready")
 	}
-
-	let applySorts = function(){
-		if(! /^\/search/.test(location.pathname)){
-			return
-		}
-		let dropdown = sorts.querySelector(".dropdown");
-		if(!dropdown){
-			setTimeout(applySorts,200);
-			return
-		}
-		let alreadyAdded = document.querySelectorAll(".hohSorts");
-		alreadyAdded.forEach(aready => aready.remove());
-		const linkHandler = function(elem, sort){
-			elem.onclick = () => {
-				sorts.__vue__.setSort(sort);
-				sorts.__vue__.close();
-			}
-		};
-		if(type === "anime"){
-			let episodeSort = create("div",["option","hohSorts"],"Episodes ↓",dropdown);
-			let episodeSortb = create("div",["option","hohSorts"],"Episodes ↑",dropdown);
-			linkHandler(episodeSort, "EPISODES_DESC")
-			linkHandler(episodeSortb, "EPISODES")
-		}
-		else if(type === "manga"){
-			let chapterSort = create("div",["option","hohSorts"],"Chapters ↓",dropdown);
-			let chapterSortb = create("div",["option","hohSorts"],"Chapters ↑",dropdown);
-			let volumeSort = create("div",["option","hohSorts"],"Volumes ↓",dropdown);
-			let volumeSortb = create("div",["option","hohSorts"],"Volumes ↑",dropdown);
-			linkHandler(chapterSort, "CHAPTERS_DESC")
-			linkHandler(chapterSortb, "CHAPTERS")
-			linkHandler(volumeSort, "VOLUMES_DESC")
-			linkHandler(volumeSortb, "VOLUMES")
-		}
+	const customAnime = {EPISODES_DESC: "Episodes ↓", EPISODES: "Episodes ↑"};
+	const customManga = {CHAPTERS_DESC: "Chapters ↓", CHAPTERS: "Chapters ↑", VOLUMES_DESC: "Volumes ↓", VOLUMES: "Volumes ↑"};
+	if(type === "anime"){
+		Object.keys(customManga).forEach(key => delete sorts.__vue__.sortOptions[key])
+		Object.assign(sorts.__vue__.sortOptions, customAnime)
 	}
-	sorts.addEventListener("click", applySorts)
+	else if(type === "manga"){
+		Object.keys(customAnime).forEach(key => delete sorts.__vue__.sortOptions[key])
+		Object.assign(sorts.__vue__.sortOptions, customManga)
+	}
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -75,7 +75,6 @@ let useScripts = {
 	entryScore: true,
 	showRecVotes: true,
 	activityTimeline: true,
-	browseFilters: true,
 	embedHentai: false,
 	comparissionPage: true,
 	noImagePolyfill: false,


### PR DESCRIPTION
What started as a fix for the custom filters disappearing ended up being a rework of the whole thing.

- converted to module
- apply custom sort filters using builtin vue object
  - I found that modifying the `sortOptions` object will immediately update the sort dropdown with any changes
  - (any valid `MediaSort` enum can be added to it, though not all of them work well)
 - added a few new sorts that allow reverse sorting of some of the default options

Anime Browse
![](https://0x0.st/HsMC.png)
Manga Browse
![](https://0x0.st/Hsur.png)
