### PR TITLE
Fix for confidence scores with Japanese titles

### DIFF
--- a/src/modules/addMediaReviewConfidence.js
+++ b/src/modules/addMediaReviewConfidence.js
@@ -5,10 +5,10 @@ exportModule({
 	categories: ["Media"],
 	visible: true,
 	urlMatch: function(url){
-		return /^https:\/\/anilist\.co\/(anime|manga)\/[0-9]+\/.*\/reviews/.test(url)
+		return /^https:\/\/anilist\.co\/(anime|manga)\/[0-9]+\/(.*\/)?reviews/.test(url)
 	},
 	code: function(){
-		const [,id] = location.pathname.match(/^\/(?:anime|manga)\/([0-9]+)\/.*\/reviews/)
+		const [,id] = location.pathname.match(/^\/(?:anime|manga)\/([0-9]+)\/(.*\/)?reviews/)
 		const query = `
 query media($id: Int, $page: Int) {
 	Media(id: $id) {


### PR DESCRIPTION
Small change to the regex for matching reviews since it looks like confidence scores aren't showing up on pages whenever an English character isn't present in the media title.