### PR TITLE
Correct English description for Hollow Hearts setting

### DIFF
--- a/src/data/languages/English.json
+++ b/src/data/languages/English.json
@@ -603,7 +603,6 @@
 "$rangeSetter_extendedDescription": "When changing the number in the \"progress\" field, a button will appear.\nWhen clicked, it sets the lower number on an activity (\"user read chapter 65 - 69 of manga\")\nYou then change the field to the higher number and click save as usual.",
 "$noAutoplay_description": "Do not autoplay videos",
 "$noAutoplay_extendedDescription": "Your browser may also provide ways to control this:\n\nFirefox: about:config > media.autoplay has a wide range of options\n\nChrome: chrome://flags/#autoplay-policy",
-"$hollowHearts_description": "Gjer hjarta hole om du ikkje har likt dei [av Reina]",
 "$anisongs_description": "Add OP/ED data to media pages [by Morimasa]",
 "$enumerateSubmissionStaff_description": "Enumerate multiple credits for staff in the submission form to help avoid duplicates",
 "$expandedListNotes_description": "Click list notes for an expanded view",

--- a/src/data/languages/Norwegian.json
+++ b/src/data/languages/Norwegian.json
@@ -466,6 +466,7 @@
 "$error_JSONparsing": "Feil ved lesing av JSON",
 "$viewAdvancedScores_description": "Vis utvida vurderingar",
 "$noAutoplay_description": "Ikkje spel av videoar automatisk",
+"$hollowHearts_description": "Gjer hjarta hole om du ikkje har likt dei [av Reina]",
 "$settings_export_description": "Kjekt å ha ein tryggingskopi. Viss du slettar cache/cookies kan Automailinnstillingane også bli borte",
 "$error_connection": "Koplingsfeil",
 "$hideGlobalFeed_description": "Skjul globalstraumen",


### PR DESCRIPTION
There were 2 instances of `hollowHearts_description` in the English section, and the second one (in Norwegian) was overwriting it.
Likewise, this description was missing from the Norwegian section.